### PR TITLE
Focus on extension traits

### DIFF
--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -200,5 +200,6 @@ where
 impl<P, Item> PredicateBooleanExt<Item> for P
 where
     P: Predicate<Item>,
+    Item: ?Sized,
 {
 }

--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -132,3 +132,73 @@ where
         !self.inner.eval(item)
     }
 }
+
+/// `Predicate` extension that adds boolean logic.
+pub trait PredicateBooleanExt<Item: ?Sized>
+where
+    Self: Predicate<Item>,
+{
+    /// Compute the logical AND of two `Predicate` results, returning the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use predicates::prelude::*;
+    ///
+    /// let predicate_fn1 = predicate::always().and(predicate::always());
+    /// let predicate_fn2 = predicate::always().and(predicate::never());
+    /// assert_eq!(true, predicate_fn1.eval(&4));
+    /// assert_eq!(false, predicate_fn2.eval(&4));
+    fn and<B>(self, other: B) -> AndPredicate<Self, B, Item>
+    where
+        B: Predicate<Item>,
+        Self: Sized,
+    {
+        AndPredicate::new(self, other)
+    }
+
+    /// Compute the logical OR of two `Predicate` results, returning the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use predicates::prelude::*;
+    ///
+    /// let predicate_fn1 = predicate::always().or(predicate::always());
+    /// let predicate_fn2 = predicate::always().or(predicate::never());
+    /// let predicate_fn3 = predicate::never().or(predicate::never());
+    /// assert_eq!(true, predicate_fn1.eval(&4));
+    /// assert_eq!(true, predicate_fn2.eval(&4));
+    /// assert_eq!(false, predicate_fn3.eval(&4));
+    fn or<B>(self, other: B) -> OrPredicate<Self, B, Item>
+    where
+        B: Predicate<Item>,
+        Self: Sized,
+    {
+        OrPredicate::new(self, other)
+    }
+
+    /// Compute the logical NOT of a `Predicate`, returning the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use predicates::prelude::*;
+    ///
+    /// let predicate_fn1 = predicate::always().not();
+    /// let predicate_fn2 = predicate::never().not();
+    /// assert_eq!(false, predicate_fn1.eval(&4));
+    /// assert_eq!(true, predicate_fn2.eval(&4));
+    fn not(self) -> NotPredicate<Self, Item>
+    where
+        Self: Sized,
+    {
+        NotPredicate::new(self)
+    }
+}
+
+impl<P, Item> PredicateBooleanExt<Item> for P
+where
+    P: Predicate<Item>,
+{
+}

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -57,3 +57,46 @@ where
         self.0.eval(variable)
     }
 }
+
+/// `Predicate` extension for boxing a `Predicate`.
+pub trait PredicateBoxExt<Item: ?Sized>
+where
+    Self: Predicate<Item>,
+{
+    /// Returns a `BoxPredicate` wrapper around this `Predicate` type.
+    ///
+    /// Returns a `BoxPredicate` wrapper around this `Predicate type. The
+    /// `BoxPredicate` type has a number of useful properties:
+    ///
+    ///   - It stores the inner predicate as a trait object, so the type of
+    ///     `BoxPredicate` will always be the same even if steps are added or
+    ///     removed from the predicate.
+    ///   - It is a common type, allowing it to be stored in vectors or other
+    ///     collection types.
+    ///   - It implements `Debug` and `Display`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use predicates::prelude::*;
+    ///
+    /// let predicates = vec![
+    ///     predicate::always().boxed(),
+    ///     predicate::never().boxed(),
+    /// ];
+    /// assert_eq!(true, predicates[0].eval(&4));
+    /// assert_eq!(false, predicates[1].eval(&4));
+    /// ```
+    fn boxed(self) -> BoxPredicate<Item>
+    where
+        Self: Sized + Send + Sync + 'static,
+    {
+        BoxPredicate::new(self)
+    }
+}
+
+impl<P, Item> PredicateBoxExt<Item> for P
+where
+    P: Predicate<Item>,
+{
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -6,8 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use boxed::BoxPredicate;
-
 /// Trait for generically evaluating a type against a dynamically created
 /// predicate function.
 ///
@@ -19,35 +17,4 @@ pub trait Predicate<Item: ?Sized> {
     /// Execute this `Predicate` against `variable`, returning the resulting
     /// boolean.
     fn eval(&self, variable: &Item) -> bool;
-
-    /// Returns a `BoxPredicate` wrapper around this `Predicate` type.
-    ///
-    /// Returns a `BoxPredicate` wrapper around this `Predicate type. The
-    /// `BoxPredicate` type has a number of useful properties:
-    ///
-    ///   - It stores the inner predicate as a trait object, so the type of
-    ///     `BoxPredicate` will always be the same even if steps are added or
-    ///     removed from the predicate.
-    ///   - It is a common type, allowing it to be stored in vectors or other
-    ///     collection types.
-    ///   - It implements `Debug` and `Display`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use predicates::prelude::*;
-    ///
-    /// let predicates = vec![
-    ///     predicate::always().boxed(),
-    ///     predicate::never().boxed(),
-    /// ];
-    /// assert_eq!(true, predicates[0].eval(&4));
-    /// assert_eq!(false, predicates[1].eval(&4));
-    /// ```
-    fn boxed(self) -> BoxPredicate<Item>
-    where
-        Self: Sized + Send + Sync + 'static,
-    {
-        BoxPredicate::new(self)
-    }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -6,7 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use boolean::{AndPredicate, NotPredicate, OrPredicate};
 use boxed::BoxPredicate;
 
 /// Trait for generically evaluating a type against a dynamically created
@@ -20,64 +19,6 @@ pub trait Predicate<Item: ?Sized> {
     /// Execute this `Predicate` against `variable`, returning the resulting
     /// boolean.
     fn eval(&self, variable: &Item) -> bool;
-
-    /// Compute the logical AND of two `Predicate` results, returning the result.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use predicates::prelude::*;
-    ///
-    /// let predicate_fn1 = predicate::always().and(predicate::always());
-    /// let predicate_fn2 = predicate::always().and(predicate::never());
-    /// assert_eq!(true, predicate_fn1.eval(&4));
-    /// assert_eq!(false, predicate_fn2.eval(&4));
-    fn and<B>(self, other: B) -> AndPredicate<Self, B, Item>
-    where
-        B: Predicate<Item>,
-        Self: Sized,
-    {
-        AndPredicate::new(self, other)
-    }
-
-    /// Compute the logical OR of two `Predicate` results, returning the result.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use predicates::prelude::*;
-    ///
-    /// let predicate_fn1 = predicate::always().or(predicate::always());
-    /// let predicate_fn2 = predicate::always().or(predicate::never());
-    /// let predicate_fn3 = predicate::never().or(predicate::never());
-    /// assert_eq!(true, predicate_fn1.eval(&4));
-    /// assert_eq!(true, predicate_fn2.eval(&4));
-    /// assert_eq!(false, predicate_fn3.eval(&4));
-    fn or<B>(self, other: B) -> OrPredicate<Self, B, Item>
-    where
-        B: Predicate<Item>,
-        Self: Sized,
-    {
-        OrPredicate::new(self, other)
-    }
-
-    /// Compute the logical NOT of a `Predicate`, returning the result.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use predicates::prelude::*;
-    ///
-    /// let predicate_fn1 = predicate::always().not();
-    /// let predicate_fn2 = predicate::never().not();
-    /// assert_eq!(false, predicate_fn1.eval(&4));
-    /// assert_eq!(true, predicate_fn2.eval(&4));
-    fn not(self) -> NotPredicate<Self, Item>
-    where
-        Self: Sized,
-    {
-        NotPredicate::new(self)
-    }
 
     /// Returns a `BoxPredicate` wrapper around this `Predicate` type.
     ///

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,7 @@
 //! Module that contains the essentials for working with predicates.
 
 pub use core::Predicate;
+pub use boolean::PredicateBooleanExt;
 
 /// Predicate factories
 pub mod predicate {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,6 +11,7 @@
 pub use core::Predicate;
 pub use boolean::PredicateBooleanExt;
 pub use boxed::PredicateBoxExt;
+pub use str::PredicateStrExt;
 
 /// Predicate factories
 pub mod predicate {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,6 +10,7 @@
 
 pub use core::Predicate;
 pub use boolean::PredicateBooleanExt;
+pub use boxed::PredicateBoxExt;
 
 /// Predicate factories
 pub mod predicate {

--- a/src/str/adapters.rs
+++ b/src/str/adapters.rs
@@ -1,0 +1,49 @@
+use Predicate;
+
+/// Predicate adaper that trims the variable being tested.
+///
+/// This is created by `pred.trim()`.
+#[derive(Copy, Clone, Debug)]
+pub struct TrimPedicate<P>
+where
+    P: Predicate<str>,
+{
+    p: P,
+}
+
+impl<P> Predicate<str> for TrimPedicate<P>
+where
+    P: Predicate<str>,
+{
+    fn eval(&self, variable: &str) -> bool {
+        self.p.eval(variable.trim())
+    }
+}
+
+/// `Predicate` extension adapting a `str` Predicate.
+pub trait PredicateStrExt
+where
+    Self: Predicate<str>,
+    Self: Sized,
+{
+    /// Returns a `TrimPedicate` that ensures the data passed to `Self` is trimmed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use predicates::prelude::*;
+    ///
+    /// let predicate_fn = predicate::str::is_empty().trim();
+    /// assert_eq!(true, predicate_fn.eval("    "));
+    /// assert_eq!(false, predicate_fn.eval("    Hello    "));
+    /// ```
+    fn trim(self) -> TrimPedicate<Self> {
+        TrimPedicate { p: self }
+    }
+}
+
+impl<P> PredicateStrExt for P
+where
+    P: Predicate<str>,
+{
+}

--- a/src/str/mod.rs
+++ b/src/str/mod.rs
@@ -12,6 +12,8 @@
 
 mod basics;
 pub use self::basics::*;
+mod adapters;
+pub use self::adapters::*;
 
 #[cfg(feature = "difference")]
 mod difference;


### PR DESCRIPTION
Existing "extra" functionality is now in extension traits.  This is a step to help pull `Predicate` in a separate crate and to set the pattern / standard for other helpers, like the ones added here.