### PR TITLE
WIP: Pretty error printer for predicates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ appveyor = { repository = "assert-rs/predicates-rs" }
 difference = { version = "2.0", optional = true }
 regex = { version="1.0", optional = true }
 float-cmp = { version="0.4", optional = true }
-term-table = { version = "0.1", optional = true }
+treeline = { version = "0.1", optional = true }
 
 [features]
 default = ["difference", "regex", "float-cmp"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ appveyor = { repository = "assert-rs/predicates-rs" }
 difference = { version = "2.0", optional = true }
 regex = { version="1.0", optional = true }
 float-cmp = { version="0.4", optional = true }
+term-table = { version = "0.1", optional = true }
 
 [features]
 default = ["difference", "regex", "float-cmp"]

--- a/examples/tree_eval.rs
+++ b/examples/tree_eval.rs
@@ -2,7 +2,8 @@ extern crate predicates;
 
 fn main() {
     use predicates::prelude::*;
-    let predicate_fn = predicate::ne(5).and(predicate::ge(5));
+    let predicate_fn = predicate::ne(5).not().and(predicate::ge(5));
 
-    println!("{}", predicate_fn.tree_eval(&7));
+    let (result, output) = predicate_fn.tree_eval(&5);
+    println!("{}", output);
 }

--- a/examples/tree_eval.rs
+++ b/examples/tree_eval.rs
@@ -1,0 +1,8 @@
+extern crate predicates;
+
+fn main() {
+    use predicates::prelude::*;
+    let predicate_fn = predicate::ne(5).and(predicate::ge(5));
+
+    println!("{}", predicate_fn.tree_eval(&7));
+}

--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -53,6 +53,16 @@ where
     fn eval(&self, item: &Item) -> bool {
         self.a.eval(item) && self.b.eval(item)
     }
+
+    fn flatten<'a, 'b>(&'a self, vec: &'b mut Vec<&'a Predicate<Item>>) {
+        vec.push(self);
+        self.a.flatten(vec);
+        self.b.flatten(vec);
+    }
+
+    fn stringify(&self, variable: &Item) -> String {
+        format!("{} && {}", self.a.stringify(variable), self.b.stringify(variable))
+    }
 }
 
 impl<M1, M2, Item> fmt::Display for AndPredicate<M1, M2, Item>

--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -21,7 +21,7 @@ pub struct AndPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
     M2: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     a: M1,
     b: M2,
@@ -32,7 +32,7 @@ impl<M1, M2, Item> AndPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
     M2: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     /// Create a new `AndPredicate` over predicates `a` and `b`.
     pub fn new(a: M1, b: M2) -> AndPredicate<M1, M2, Item> {
@@ -48,7 +48,7 @@ impl<M1, M2, Item> Predicate<Item> for AndPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
     M2: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     fn eval(&self, item: &Item) -> bool {
         self.a.eval(item) && self.b.eval(item)
@@ -59,7 +59,7 @@ impl<M1, M2, Item> fmt::Display for AndPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
     M2: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({} && {})", self.a, self.b)
@@ -74,7 +74,7 @@ pub struct OrPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
     M2: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     a: M1,
     b: M2,
@@ -85,7 +85,7 @@ impl<M1, M2, Item> OrPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
     M2: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     /// Create a new `OrPredicate` over predicates `a` and `b`.
     pub fn new(a: M1, b: M2) -> OrPredicate<M1, M2, Item> {
@@ -101,7 +101,7 @@ impl<M1, M2, Item> Predicate<Item> for OrPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
     M2: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     fn eval(&self, item: &Item) -> bool {
         self.a.eval(item) || self.b.eval(item)
@@ -112,7 +112,7 @@ impl<M1, M2, Item> fmt::Display for OrPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
     M2: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({} || {})", self.a, self.b)
@@ -126,7 +126,7 @@ where
 pub struct NotPredicate<M, Item>
 where
     M: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     inner: M,
     _phantom: PhantomData<Item>,
@@ -135,7 +135,7 @@ where
 impl<M, Item> NotPredicate<M, Item>
 where
     M: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     /// Create a new `NotPredicate` over predicate `inner`.
     pub fn new(inner: M) -> NotPredicate<M, Item> {
@@ -149,7 +149,7 @@ where
 impl<M, Item> Predicate<Item> for NotPredicate<M, Item>
 where
     M: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     fn eval(&self, item: &Item) -> bool {
         !self.inner.eval(item)
@@ -159,7 +159,7 @@ where
 impl<M, Item> fmt::Display for NotPredicate<M, Item>
 where
     M: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "(! {})", self.inner)
@@ -167,7 +167,7 @@ where
 }
 
 /// `Predicate` extension that adds boolean logic.
-pub trait PredicateBooleanExt<Item: ?Sized>
+pub trait PredicateBooleanExt<Item: ?Sized + fmt::Debug>
 where
     Self: Predicate<Item>,
 {
@@ -233,6 +233,6 @@ where
 impl<P, Item> PredicateBooleanExt<Item> for P
 where
     P: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
 }

--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -164,6 +164,15 @@ where
     fn eval(&self, item: &Item) -> bool {
         !self.inner.eval(item)
     }
+
+    fn flatten<'a, 'b>(&'a self, vec: &'b mut Vec<&'a Predicate<Item>>) {
+        vec.push(self);
+        vec.push(&self.inner);
+    }
+
+    fn stringify(&self, item: &Item) -> String {
+        format!("!({})", self.inner.stringify(item))
+    }
 }
 
 impl<M, Item> fmt::Display for NotPredicate<M, Item>

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -15,11 +15,11 @@ use Predicate;
 
 /// `Predicate` that wraps another `Predicate` as a trait object, allowing
 /// sized storage of predicate types.
-pub struct BoxPredicate<Item: ?Sized>(Box<Predicate<Item> + Send + Sync>);
+pub struct BoxPredicate<Item: ?Sized + fmt::Debug>(Box<Predicate<Item> + Send + Sync>);
 
 impl<Item> BoxPredicate<Item>
 where
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     /// Creates a new `BoxPredicate`, a wrapper around a dynamically-dispatched
     /// `Predicate` type with useful trait impls.
@@ -33,7 +33,7 @@ where
 
 impl<Item> fmt::Debug for BoxPredicate<Item>
 where
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BoxPredicate").finish()
@@ -42,7 +42,7 @@ where
 
 impl<Item> fmt::Display for BoxPredicate<Item>
 where
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
@@ -51,7 +51,7 @@ where
 
 impl<Item> Predicate<Item> for BoxPredicate<Item>
 where
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     fn eval(&self, variable: &Item) -> bool {
         self.0.eval(variable)
@@ -59,7 +59,7 @@ where
 }
 
 /// `Predicate` extension for boxing a `Predicate`.
-pub trait PredicateBoxExt<Item: ?Sized>
+pub trait PredicateBoxExt<Item: ?Sized + fmt::Debug>
 where
     Self: Predicate<Item>,
 {
@@ -98,5 +98,6 @@ where
 impl<P, Item> PredicateBoxExt<Item> for P
 where
     P: Predicate<Item>,
+    Item: ?Sized + fmt::Debug
 {
 }

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -22,7 +22,7 @@ pub struct BooleanPredicate<Item> {
     _phantom: PhantomData<Item>,
 }
 
-impl<Item> Predicate<Item> for BooleanPredicate<Item> {
+impl<Item: fmt::Debug> Predicate<Item> for BooleanPredicate<Item> {
     fn eval(&self, _variable: &Item) -> bool {
         self.retval
     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -15,8 +15,13 @@ use std::fmt;
 /// mean that the evaluated item is in some sort of pre-defined set.  This is
 /// different from `Ord` and `Eq` in that an `item` will almost never be the
 /// same type as the implementing `Predicate` type.
-pub trait Predicate<Item: ?Sized>: fmt::Display {
+pub trait Predicate<Item: ?Sized + fmt::Debug>: fmt::Display {
     /// Execute this `Predicate` against `variable`, returning the resulting
     /// boolean.
     fn eval(&self, variable: &Item) -> bool;
+
+    /// TODO
+    fn eval_to_string(&self, variable: &Item) -> String {
+        format!("pred = {}, actual = {:?}", self, variable)
+    }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -51,11 +51,12 @@ where
     }
 }
 
-impl<F, T> Predicate<T> for FnPredicate<F, T>
+impl<F, Item> Predicate<Item> for FnPredicate<F, Item>
 where
-    F: Fn(&T) -> bool,
+    F: Fn(&Item) -> bool,
+    Item: fmt::Debug
 {
-    fn eval(&self, variable: &T) -> bool {
+    fn eval(&self, variable: &Item) -> bool {
         (self.function)(variable)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,8 @@ extern crate difference;
 extern crate float_cmp;
 #[cfg(feature = "regex")]
 extern crate regex;
-#[cfg(feature = "term-table")]
-extern crate term_table;
+#[cfg(feature = "treeline")]
+extern crate treeline;
 
 pub mod prelude;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,8 @@ extern crate difference;
 extern crate float_cmp;
 #[cfg(feature = "regex")]
 extern crate regex;
+#[cfg(feature = "term-table")]
+extern crate term_table;
 
 pub mod prelude;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,7 @@
+extern crate predicates;
+
+fn main() {
+    use predicates::prelude::*;
+    let predicate_fn = predicate::ne(5);
+    println!("{}", predicate_fn.eval_to_string(&7));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,0 @@
-extern crate predicates;
-
-fn main() {
-    use predicates::prelude::*;
-    let predicate_fn = predicate::ne(5);
-    println!("{}", predicate_fn.eval_to_string(&7));
-}

--- a/src/name.rs
+++ b/src/name.rs
@@ -20,7 +20,7 @@ use Predicate;
 pub struct NamePredicate<M, Item>
 where
     M: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     inner: M,
     name: &'static str,
@@ -30,7 +30,7 @@ where
 impl<M, Item> Predicate<Item> for NamePredicate<M, Item>
 where
     M: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     fn eval(&self, item: &Item) -> bool {
         self.inner.eval(item)
@@ -40,7 +40,7 @@ where
 impl<M, Item> fmt::Display for NamePredicate<M, Item>
 where
     M: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.name)
@@ -48,7 +48,7 @@ where
 }
 
 /// `Predicate` extension that adds naming predicate expressions.
-pub trait PredicateNameExt<Item: ?Sized>
+pub trait PredicateNameExt<Item: ?Sized + fmt::Debug>
 where
     Self: Predicate<Item>,
 {
@@ -77,6 +77,6 @@ where
 impl<P, Item> PredicateNameExt<Item> for P
 where
     P: Predicate<Item>,
-    Item: ?Sized,
+    Item: ?Sized + fmt::Debug,
 {
 }

--- a/src/ord.rs
+++ b/src/ord.rs
@@ -10,6 +10,9 @@
 
 use std::fmt;
 
+#[cfg(feature = "treeline")]
+use treeline::Tree;
+
 use Predicate;
 
 #[derive(Clone, Copy, Debug)]
@@ -52,12 +55,19 @@ where
         }
     }
 
-    fn flatten<'a, 'b>(&'a self, vec: &'b mut Vec<&'a Predicate<Item>>) {
-        vec.push(self);
+    #[cfg(feature = "treeline")]
+    fn make_tree(&self, item: &Item) -> Tree<String> {
+        Tree::root(
+            format!(
+                "{} {}",
+                self.stringify(item),
+                ::core::pass_fail(self.eval(item))
+            )
+        )
     }
 
-    fn stringify(&self, variable: &Item) -> String {
-        format!("{:?} {} {:?}", variable, self.op, self.constant)
+    fn stringify(&self, item: &Item) -> String {
+        format!("{:?} {} {:?}", item, self.op, self.constant)
     }
 }
 
@@ -66,7 +76,7 @@ where
     T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {:?}", self.op, self.constant)
+        write!(f, "var {} {:?}", self.op, self.constant)
     }
 }
 
@@ -160,12 +170,19 @@ where
         }
     }
 
-    fn flatten<'a, 'b>(&'a self, vec: &'b mut Vec<&'a Predicate<Item>>) {
-        vec.push(self);
+    #[cfg(feature = "treeline")]
+    fn make_tree(&self, item: &Item) -> Tree<String> {
+        Tree::root(
+            format!(
+                "{} {}",
+                self.stringify(item),
+                ::core::pass_fail(self.eval(item))
+            )
+        )
     }
 
-    fn stringify(&self, variable: &Item) -> String {
-        format!("{:?} {} {:?}", variable, self.op, self.constant)
+    fn stringify(&self, item: &Item) -> String {
+        format!("{:?} {} {:?}", item, self.op, self.constant)
     }
 }
 

--- a/src/ord.rs
+++ b/src/ord.rs
@@ -41,15 +41,23 @@ where
     op: EqOps,
 }
 
-impl<T> Predicate<T> for EqPredicate<T>
+impl<Item> Predicate<Item> for EqPredicate<Item>
 where
-    T: PartialEq + fmt::Debug,
+    Item: PartialEq + fmt::Debug,
 {
-    fn eval(&self, variable: &T) -> bool {
+    fn eval(&self, variable: &Item) -> bool {
         match self.op {
             EqOps::Equal => variable.eq(&self.constant),
             EqOps::NotEqual => variable.ne(&self.constant),
         }
+    }
+
+    fn flatten<'a, 'b>(&'a self, vec: &'b mut Vec<&'a Predicate<Item>>) {
+        vec.push(self);
+    }
+
+    fn stringify(&self, variable: &Item) -> String {
+        format!("{:?} {} {:?}", variable, self.op, self.constant)
     }
 }
 
@@ -58,7 +66,7 @@ where
     T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "var {} {:?}", self.op, self.constant)
+        write!(f, "{} {:?}", self.op, self.constant)
     }
 }
 
@@ -139,17 +147,25 @@ where
     op: OrdOps,
 }
 
-impl<T> Predicate<T> for OrdPredicate<T>
+impl<Item> Predicate<Item> for OrdPredicate<Item>
 where
-    T: PartialOrd + fmt::Debug,
+    Item: PartialOrd + fmt::Debug,
 {
-    fn eval(&self, variable: &T) -> bool {
+    fn eval(&self, variable: &Item) -> bool {
         match self.op {
             OrdOps::LessThan => variable.lt(&self.constant),
             OrdOps::LessThanOrEqual => variable.le(&self.constant),
             OrdOps::GreaterThanOrEqual => variable.ge(&self.constant),
             OrdOps::GreaterThan => variable.gt(&self.constant),
         }
+    }
+
+    fn flatten<'a, 'b>(&'a self, vec: &'b mut Vec<&'a Predicate<Item>>) {
+        vec.push(self);
+    }
+
+    fn stringify(&self, variable: &Item) -> String {
+        format!("{:?} {} {:?}", variable, self.op, self.constant)
     }
 }
 


### PR DESCRIPTION
Currently missing implements for a lot of the predicates currently only `AndPredicate`, `OrdPredicate`, and `EqPredicate` have correct impls.

## Table Output
```
╔═══════════════════════╦══════════╗
║ PREDICATE             ║ ROW      ║
╠═══════════════════════╬══════════╣
║ !(5 != 5) && 5 >= 5   ║ PASSED   ║
╠═══════════════════════╬══════════╣
║ !(5 != 5)             ║ PASSED   ║
╠═══════════════════════╬══════════╣
║ 5 != 5                ║ FAILED   ║
╠═══════════════════════╬══════════╣
║ 5 >= 5                ║ PASSED   ║
╚═══════════════════════╩══════════╝
```

## Tree Output
```
!(5 != 5) && 5 >= 5 PASSED
├── !(5 != 5) PASSED
|   └── 5 != 5 FAILED
└── 5 >= 5 PASSED
```
<!--
Quick reminders:
- Were tests written?
- Is commit history clean?
- Were copyright statements updated?
-->