### PR TITLE
refactor: Reduce reuse

### DIFF
--- a/src/path/fc.rs
+++ b/src/path/fc.rs
@@ -10,22 +10,17 @@ use std::fmt;
 use std::fs;
 use std::io::{self, Read};
 use std::path;
-use std::str;
 
 use Predicate;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct FileContent(Vec<u8>);
+struct FileContent(Vec<u8>);
 
 impl FileContent {
     pub fn new(path: &path::Path) -> io::Result<FileContent> {
         let mut buffer = Vec::new();
         fs::File::open(path)?.read_to_end(&mut buffer)?;
         Ok(FileContent(buffer))
-    }
-
-    pub fn utf8(&self) -> Result<&str, str::Utf8Error> {
-        str::from_utf8(&self.0)
     }
 }
 

--- a/src/path/fs.rs
+++ b/src/path/fs.rs
@@ -7,11 +7,27 @@
 // except according to those terms.
 
 use std::fmt;
-use std::io;
+use std::fs;
+use std::io::{self, Read};
 use std::path;
+use std::str;
 
 use Predicate;
-use path::fc::FileContent;
+
+#[derive(Clone, Debug, PartialEq)]
+struct FileContent(Vec<u8>);
+
+impl FileContent {
+    pub fn new(path: &path::Path) -> io::Result<FileContent> {
+        let mut buffer = Vec::new();
+        fs::File::open(path)?.read_to_end(&mut buffer)?;
+        Ok(FileContent(buffer))
+    }
+
+    pub fn utf8(&self) -> Result<&str, str::Utf8Error> {
+        str::from_utf8(&self.0)
+    }
+}
 
 /// Predicate that compares file matches
 #[derive(Clone, Debug)]


### PR DESCRIPTION
The reuse here is of little value but removing it gives a lot more
freedom in refactorung ... or disabling parts of the crate during major
refactors.

<!--
Quick reminders:
- Were tests written?
- Is commit history clean?
- Were copyright statements updated?
-->
