### PR TITLE
feat: Fix eq for str

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -53,8 +53,11 @@ where
     /// assert_eq!(true, predicate_fn.eval(&1));
     /// assert_eq!(false, predicate_fn.eval(&2));
     /// assert_eq!(true, predicate_fn.eval(&3));
-    /// assert_eq!(false, predicate_fn.eval(&4));
-    /// assert_eq!(true, predicate_fn.eval(&5));
+    ///
+    /// let predicate_fn = predicate::in_iter(vec!["a", "c", "e"]).sort();
+    /// assert_eq!(true, predicate_fn.eval("a"));
+    /// assert_eq!(false, predicate_fn.eval("b"));
+    /// assert_eq!(true, predicate_fn.eval("c"));
     /// ```
     pub fn sort(self) -> OrdInPredicate<T> {
         let mut items = self.inner;
@@ -69,6 +72,15 @@ where
 {
     fn eval(&self, variable: &T) -> bool {
         self.inner.contains(variable)
+    }
+}
+
+impl<'a, T> Predicate<T> for InPredicate<&'a T>
+where
+    T: PartialEq + fmt::Debug + ?Sized,
+{
+    fn eval(&self, variable: &T) -> bool {
+        self.inner.contains(&variable)
     }
 }
 
@@ -104,8 +116,11 @@ where
 /// assert_eq!(true, predicate_fn.eval(&1));
 /// assert_eq!(false, predicate_fn.eval(&2));
 /// assert_eq!(true, predicate_fn.eval(&3));
-/// assert_eq!(false, predicate_fn.eval(&4));
-/// assert_eq!(true, predicate_fn.eval(&5));
+///
+/// let predicate_fn = predicate::in_iter(vec!["a", "c", "e"]);
+/// assert_eq!(true, predicate_fn.eval("a"));
+/// assert_eq!(false, predicate_fn.eval("b"));
+/// assert_eq!(true, predicate_fn.eval("c"));
 /// ```
 pub fn in_iter<I, T>(iter: I) -> InPredicate<T>
 where
@@ -140,6 +155,15 @@ where
 {
     fn eval(&self, variable: &T) -> bool {
         self.inner.binary_search(variable).is_ok()
+    }
+}
+
+impl<'a, T> Predicate<T> for OrdInPredicate<&'a T>
+where
+    T: Ord + fmt::Debug + ?Sized,
+{
+    fn eval(&self, variable: &T) -> bool {
+        self.inner.binary_search(&variable).is_ok()
     }
 }
 
@@ -178,6 +202,15 @@ where
     }
 }
 
+impl<'a, T> Predicate<T> for HashableInPredicate<&'a T>
+where
+    T: Hash + Eq + fmt::Debug + ?Sized,
+{
+    fn eval(&self, variable: &T) -> bool {
+        self.inner.contains(&variable)
+    }
+}
+
 impl<T> fmt::Display for HashableInPredicate<T>
 where
     T: Hash + Eq + fmt::Debug,
@@ -204,8 +237,11 @@ where
 /// assert_eq!(true, predicate_fn.eval(&1));
 /// assert_eq!(false, predicate_fn.eval(&2));
 /// assert_eq!(true, predicate_fn.eval(&3));
-/// assert_eq!(false, predicate_fn.eval(&4));
-/// assert_eq!(true, predicate_fn.eval(&5));
+///
+/// let predicate_fn = predicate::in_hash(vec!["a", "c", "e"]);
+/// assert_eq!(true, predicate_fn.eval("a"));
+/// assert_eq!(false, predicate_fn.eval("b"));
+/// assert_eq!(true, predicate_fn.eval("c"));
 /// ```
 pub fn in_hash<I, T>(iter: I) -> HashableInPredicate<T>
 where

--- a/src/ord.rs
+++ b/src/ord.rs
@@ -53,6 +53,18 @@ where
     }
 }
 
+impl<'a, T> Predicate<T> for EqPredicate<&'a T>
+where
+    T: PartialEq + fmt::Debug + ?Sized,
+{
+    fn eval(&self, variable: &T) -> bool {
+        match self.op {
+            EqOps::Equal => variable.eq(self.constant),
+            EqOps::NotEqual => variable.ne(self.constant),
+        }
+    }
+}
+
 impl<T> fmt::Display for EqPredicate<T>
 where
     T: fmt::Debug,
@@ -73,6 +85,10 @@ where
 /// let predicate_fn = predicate::eq(5);
 /// assert_eq!(true, predicate_fn.eval(&5));
 /// assert_eq!(false, predicate_fn.eval(&10));
+///
+/// let predicate_fn = predicate::eq("Hello");
+/// assert_eq!(true, predicate_fn.eval("Hello"));
+/// assert_eq!(false, predicate_fn.eval("Goodbye"));
 /// ```
 pub fn eq<T>(constant: T) -> EqPredicate<T>
 where
@@ -153,6 +169,20 @@ where
     }
 }
 
+impl<'a, T> Predicate<T> for OrdPredicate<&'a T>
+where
+    T: PartialOrd + fmt::Debug + ?Sized,
+{
+    fn eval(&self, variable: &T) -> bool {
+        match self.op {
+            OrdOps::LessThan => variable.lt(self.constant),
+            OrdOps::LessThanOrEqual => variable.le(self.constant),
+            OrdOps::GreaterThanOrEqual => variable.ge(self.constant),
+            OrdOps::GreaterThan => variable.gt(self.constant),
+        }
+    }
+}
+
 impl<T> fmt::Display for OrdPredicate<T>
 where
     T: fmt::Debug,
@@ -173,6 +203,10 @@ where
 /// let predicate_fn = predicate::lt(5);
 /// assert_eq!(true, predicate_fn.eval(&4));
 /// assert_eq!(false, predicate_fn.eval(&6));
+///
+/// let predicate_fn = predicate::lt("b");
+/// assert_eq!(true, predicate_fn.eval("a"));
+/// assert_eq!(false, predicate_fn.eval("c"));
 /// ```
 pub fn lt<T>(constant: T) -> OrdPredicate<T>
 where


### PR DESCRIPTION
`eq("str")` wouldn't produce a `Predicate<str>` but instead a
`Predicate<&str>`, requiring the user to pass in a `&&str`.

<!--
Quick reminders:
- Were tests written?
- Is commit history clean?
- Were copyright statements updated?
-->
