### PR TITLE
feat: Expand trait coverage

### DIFF
--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -16,7 +16,7 @@ use Predicate;
 /// Predicate that combines two `Predicate`s, returning the AND of the results.
 ///
 /// This is created by the `Predicate::and` function.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AndPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
@@ -69,7 +69,7 @@ where
 /// Predicate that combines two `Predicate`s, returning the OR of the results.
 ///
 /// This is created by the `Predicate::or` function.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OrPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
@@ -122,7 +122,7 @@ where
 /// Predicate that returns a `Predicate` taking the logical NOT of the result.
 ///
 /// This is created by the `Predicate::not` function.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NotPredicate<M, Item>
 where
     M: Predicate<Item>,

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -16,7 +16,7 @@ use Predicate;
 /// Predicate that always returns a constant (boolean) result.
 ///
 /// This is created by the `predicate::always` and `predicate::never` functions.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BooleanPredicate<Item> {
     retval: bool,
     _phantom: PhantomData<Item>,

--- a/src/float/close.rs
+++ b/src/float/close.rs
@@ -17,7 +17,7 @@ use Predicate;
 /// occur.
 ///
 /// This is created by the `predicate::float::is_close`.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct IsClosePredicate {
     target: f64,
     epsilon: f64,

--- a/src/function.rs
+++ b/src/function.rs
@@ -15,7 +15,7 @@ use Predicate;
 
 /// Predicate that wraps a function over a reference that returns a `bool`.
 /// This type is returned by the `predicate::function` function.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FnPredicate<F, T>
 where
     F: Fn(&T) -> bool,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -24,7 +24,7 @@ use Predicate;
 /// it is much more efficient to use `HashableInPredicate` and
 /// `in_hash`. The implementation-specific predicates will be
 /// deprecated when Rust supports trait specialization.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InPredicate<T>
 where
     T: PartialEq + fmt::Debug,
@@ -141,7 +141,7 @@ where
 /// predicates will be deprecated when Rust supports trait specialization.
 ///
 /// This is created by the `predicate::in_iter(...).sort` function.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrdInPredicate<T>
 where
     T: Ord + fmt::Debug,
@@ -185,7 +185,7 @@ where
 /// predicates will be deprecated when Rust supports trait specialization.
 ///
 /// This is created by the `predicate::in_hash` function.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HashableInPredicate<T>
 where
     T: Hash + Eq + fmt::Debug,

--- a/src/name.rs
+++ b/src/name.rs
@@ -16,7 +16,7 @@ use Predicate;
 /// Augment an existing predicate with a name.
 ///
 /// This is created by the `PredicateNameExt::name` function.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NamePredicate<M, Item>
 where
     M: Predicate<Item>,

--- a/src/ord.rs
+++ b/src/ord.rs
@@ -12,7 +12,7 @@ use std::fmt;
 
 use Predicate;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum EqOps {
     Equal,
     NotEqual,
@@ -32,10 +32,10 @@ impl fmt::Display for EqOps {
 /// value, otherwise returns `false`.
 ///
 /// This is created by the `predicate::{eq, ne}` functions.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EqPredicate<T>
 where
-    T: fmt::Debug,
+    T: fmt::Debug + PartialEq,
 {
     constant: T,
     op: EqOps,
@@ -43,7 +43,7 @@ where
 
 impl<T> Predicate<T> for EqPredicate<T>
 where
-    T: PartialEq + fmt::Debug,
+    T: fmt::Debug + PartialEq,
 {
     fn eval(&self, variable: &T) -> bool {
         match self.op {
@@ -55,7 +55,7 @@ where
 
 impl<'a, T> Predicate<T> for EqPredicate<&'a T>
 where
-    T: PartialEq + fmt::Debug + ?Sized,
+    T: fmt::Debug + PartialEq + ?Sized,
 {
     fn eval(&self, variable: &T) -> bool {
         match self.op {
@@ -67,7 +67,7 @@ where
 
 impl<T> fmt::Display for EqPredicate<T>
 where
-    T: fmt::Debug,
+    T: fmt::Debug + PartialEq,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "var {} {:?}", self.op, self.constant)
@@ -92,7 +92,7 @@ where
 /// ```
 pub fn eq<T>(constant: T) -> EqPredicate<T>
 where
-    T: PartialEq + fmt::Debug,
+    T: fmt::Debug + PartialEq,
 {
     EqPredicate {
         constant: constant,
@@ -122,7 +122,7 @@ where
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum OrdOps {
     LessThan,
     LessThanOrEqual,
@@ -146,10 +146,10 @@ impl fmt::Display for OrdOps {
 /// value, otherwise returns `false`.
 ///
 /// This is created by the `predicate::{gt, ge, lt, le}` functions.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OrdPredicate<T>
 where
-    T: fmt::Debug,
+    T: fmt::Debug + PartialOrd,
 {
     constant: T,
     op: OrdOps,
@@ -157,7 +157,7 @@ where
 
 impl<T> Predicate<T> for OrdPredicate<T>
 where
-    T: PartialOrd + fmt::Debug,
+    T: fmt::Debug + PartialOrd,
 {
     fn eval(&self, variable: &T) -> bool {
         match self.op {
@@ -171,7 +171,7 @@ where
 
 impl<'a, T> Predicate<T> for OrdPredicate<&'a T>
 where
-    T: PartialOrd + fmt::Debug + ?Sized,
+    T: fmt::Debug + PartialOrd + ?Sized,
 {
     fn eval(&self, variable: &T) -> bool {
         match self.op {
@@ -185,7 +185,7 @@ where
 
 impl<T> fmt::Display for OrdPredicate<T>
 where
-    T: fmt::Debug,
+    T: fmt::Debug + PartialOrd,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "var {} {:?}", self.op, self.constant)
@@ -210,7 +210,7 @@ where
 /// ```
 pub fn lt<T>(constant: T) -> OrdPredicate<T>
 where
-    T: PartialOrd + fmt::Debug,
+    T: fmt::Debug + PartialOrd,
 {
     OrdPredicate {
         constant: constant,

--- a/src/path/existence.rs
+++ b/src/path/existence.rs
@@ -14,7 +14,7 @@ use Predicate;
 /// Predicate that checks if a file is present
 ///
 /// This is created by the `predicate::path::exists` and `predicate::path::missing`.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExistencePredicate {
     exists: bool,
 }

--- a/src/path/fc.rs
+++ b/src/path/fc.rs
@@ -13,7 +13,7 @@ use std::path;
 
 use Predicate;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 struct FileContent(Vec<u8>);
 
 impl FileContent {
@@ -24,10 +24,10 @@ impl FileContent {
     }
 }
 
-/// Predicate adaper that converts a `path` to file content predicate to byte predicate.
+/// Predicate adapter that converts a `path` predicate to a byte predicate on its content.
 ///
 /// This is created by `pred.from_path()`.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FileContentPredicate<P>
 where
     P: Predicate<[u8]>,

--- a/src/path/fs.rs
+++ b/src/path/fs.rs
@@ -14,7 +14,7 @@ use std::str;
 
 use Predicate;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct FileContent(Vec<u8>);
 
 impl FileContent {
@@ -30,7 +30,7 @@ impl FileContent {
 }
 
 /// Predicate that compares file matches
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinaryFilePredicate {
     path: path::PathBuf,
     file_content: FileContent,
@@ -98,7 +98,7 @@ pub fn eq_file(path: &path::Path) -> BinaryFilePredicate {
 }
 
 /// Predicate that compares string content of files
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StrFilePredicate {
     path: path::PathBuf,
     content: String,

--- a/src/path/ft.rs
+++ b/src/path/ft.rs
@@ -13,7 +13,7 @@ use std::path;
 
 use Predicate;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FileType {
     File,
     Dir,
@@ -55,7 +55,7 @@ impl fmt::Display for FileType {
 /// Predicate that checks the `std::fs::FileType`.
 ///
 /// This is created by the `predicate::path::is_file`, `predicate::path::is_dir`, and `predicate::path::is_symlink`.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FileTypePredicate {
     ft: FileType,
     follow: bool,

--- a/src/str/adapters.rs
+++ b/src/str/adapters.rs
@@ -7,7 +7,7 @@ use Predicate;
 /// Predicate adaper that trims the variable being tested.
 ///
 /// This is created by `pred.trim()`.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TrimPredicate<P>
 where
     P: Predicate<str>,
@@ -36,7 +36,7 @@ where
 /// Predicate adaper that converts a `str` predicate to byte predicate.
 ///
 /// This is created by `pred.from_utf8()`.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Utf8Predicate<P>
 where
     P: Predicate<str>,

--- a/src/str/basics.rs
+++ b/src/str/basics.rs
@@ -13,7 +13,7 @@ use Predicate;
 /// Predicate that checks for empty strings.
 ///
 /// This is created by `predicates::str::is_empty`.
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IsEmptyPredicate {}
 
 impl Predicate<str> for IsEmptyPredicate {
@@ -46,7 +46,7 @@ pub fn is_empty() -> IsEmptyPredicate {
 /// Predicate checks start of str
 ///
 /// This is created by `predicates::str::starts_with`.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StartsWithPredicate {
     pattern: String,
 }
@@ -86,7 +86,7 @@ where
 /// Predicate checks end of str
 ///
 /// This is created by `predicates::str::ends_with`.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EndsWithPredicate {
     pattern: String,
 }
@@ -126,7 +126,7 @@ where
 /// Predicate that checks for patterns.
 ///
 /// This is created by `predicates::str:contains`.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContainsPredicate {
     pattern: String,
 }
@@ -166,7 +166,7 @@ impl fmt::Display for ContainsPredicate {
 /// Predicate that checks for repeated patterns.
 ///
 /// This is created by `predicates::str::contains(...).count`.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MatchesPredicate {
     pattern: String,
     count: usize,

--- a/src/str/difference.rs
+++ b/src/str/difference.rs
@@ -13,7 +13,7 @@ use difference;
 
 use Predicate;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DistanceOp {
     Similar,
     Different,
@@ -31,7 +31,7 @@ impl DistanceOp {
 /// Predicate that diffs two strings.
 ///
 /// This is created by the `predicate::str::similar`.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DifferencePredicate {
     orig: borrow::Cow<'static, str>,
     split: borrow::Cow<'static, str>,

--- a/src/str/regex.rs
+++ b/src/str/regex.rs
@@ -18,7 +18,7 @@ pub type RegexError = regex::Error;
 /// Predicate that uses regex matching
 ///
 /// This is created by the `predicate::str::is_match`.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub struct RegexPredicate {
     re: regex::Regex,
 }
@@ -55,7 +55,7 @@ impl fmt::Display for RegexPredicate {
 /// Predicate that checks for repeated patterns.
 ///
 /// This is created by `predicates::str::is_match(...).count`.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub struct RegexMatchesPredicate {
     re: regex::Regex,
     count: usize,


### PR DESCRIPTION
We now consistently apply `Clone`, `Copy`, `PartialEq`, and `Eq`. It
looks like the derive macros are smart enough to conditionalize the
trait implementations for us.

<!--
Quick reminders:
- Were tests written?
- Is commit history clean?
- Were copyright statements updated?
-->
