### PR TITLE
WIP feat: Add basic reflection

### DIFF
--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -62,6 +62,13 @@ where
     M2: Predicate<Item>,
     Item: ?Sized,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![
+            reflection::Child::new("left", &self.a),
+            reflection::Child::new("right", &self.b),
+        ];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<M1, M2, Item> fmt::Display for AndPredicate<M1, M2, Item>
@@ -123,6 +130,13 @@ where
     M2: Predicate<Item>,
     Item: ?Sized,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![
+            reflection::Child::new("left", &self.a),
+            reflection::Child::new("right", &self.b),
+        ];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<M1, M2, Item> fmt::Display for OrPredicate<M1, M2, Item>
@@ -178,6 +192,10 @@ where
     M: Predicate<Item>,
     Item: ?Sized,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![reflection::Child::new("predicate", &self.inner)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<M, Item> fmt::Display for NotPredicate<M, Item>

--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -11,6 +11,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
+use reflection;
 use Predicate;
 
 /// Predicate that combines two `Predicate`s, returning the AND of the results.
@@ -53,6 +54,14 @@ where
     fn eval(&self, item: &Item) -> bool {
         self.a.eval(item) && self.b.eval(item)
     }
+}
+
+impl<M1, M2, Item> reflection::PredicateReflection for AndPredicate<M1, M2, Item>
+where
+    M1: Predicate<Item>,
+    M2: Predicate<Item>,
+    Item: ?Sized,
+{
 }
 
 impl<M1, M2, Item> fmt::Display for AndPredicate<M1, M2, Item>
@@ -108,6 +117,14 @@ where
     }
 }
 
+impl<M1, M2, Item> reflection::PredicateReflection for OrPredicate<M1, M2, Item>
+where
+    M1: Predicate<Item>,
+    M2: Predicate<Item>,
+    Item: ?Sized,
+{
+}
+
 impl<M1, M2, Item> fmt::Display for OrPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
@@ -154,6 +171,13 @@ where
     fn eval(&self, item: &Item) -> bool {
         !self.inner.eval(item)
     }
+}
+
+impl<M, Item> reflection::PredicateReflection for NotPredicate<M, Item>
+where
+    M: Predicate<Item>,
+    Item: ?Sized,
+{
 }
 
 impl<M, Item> fmt::Display for NotPredicate<M, Item>

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -11,6 +11,7 @@
 
 use std::fmt;
 
+use reflection;
 use Predicate;
 
 /// `Predicate` that wraps another `Predicate` as a trait object, allowing
@@ -38,6 +39,12 @@ where
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BoxPredicate").finish()
     }
+}
+
+impl<Item> reflection::PredicateReflection for BoxPredicate<Item>
+where
+    Item: ?Sized,
+{
 }
 
 impl<Item> fmt::Display for BoxPredicate<Item>

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -45,6 +45,13 @@ impl<Item> reflection::PredicateReflection for BoxPredicate<Item>
 where
     Item: ?Sized,
 {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        self.0.parameters()
+    }
+
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        self.0.children()
+    }
 }
 
 impl<Item> fmt::Display for BoxPredicate<Item>

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -29,7 +29,12 @@ impl<Item> Predicate<Item> for BooleanPredicate<Item> {
     }
 }
 
-impl<Item> reflection::PredicateReflection for BooleanPredicate<Item> {}
+impl<Item> reflection::PredicateReflection for BooleanPredicate<Item> {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("value", &self.retval)];
+        Box::new(params.into_iter())
+    }
+}
 
 impl<Item> fmt::Display for BooleanPredicate<Item> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -11,6 +11,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
+use reflection;
 use Predicate;
 
 /// Predicate that always returns a constant (boolean) result.
@@ -27,6 +28,8 @@ impl<Item> Predicate<Item> for BooleanPredicate<Item> {
         self.retval
     }
 }
+
+impl<Item> reflection::PredicateReflection for BooleanPredicate<Item> {}
 
 impl<Item> fmt::Display for BooleanPredicate<Item> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/core.rs
+++ b/src/core.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt;
+use reflection;
 
 /// Trait for generically evaluating a type against a dynamically created
 /// predicate function.
@@ -15,7 +15,7 @@ use std::fmt;
 /// mean that the evaluated item is in some sort of pre-defined set.  This is
 /// different from `Ord` and `Eq` in that an `item` will almost never be the
 /// same type as the implementing `Predicate` type.
-pub trait Predicate<Item: ?Sized>: fmt::Display {
+pub trait Predicate<Item: ?Sized>: reflection::PredicateReflection {
     /// Execute this `Predicate` against `variable`, returning the resulting
     /// boolean.
     fn eval(&self, variable: &Item) -> bool;

--- a/src/float/close.rs
+++ b/src/float/close.rs
@@ -87,15 +87,19 @@ impl Predicate<f64> for IsClosePredicate {
     }
 }
 
-impl reflection::PredicateReflection for IsClosePredicate {}
+impl reflection::PredicateReflection for IsClosePredicate {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![
+            reflection::Parameter::new("epsilon", &self.epsilon),
+            reflection::Parameter::new("ulps", &self.ulps),
+        ];
+        Box::new(params.into_iter())
+    }
+}
 
 impl fmt::Display for IsClosePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "var ~= {} +/- {} ({})",
-            self.target, self.epsilon, self.ulps
-        )
+        write!(f, "var ~= {}", self.target)
     }
 }
 

--- a/src/float/close.rs
+++ b/src/float/close.rs
@@ -11,6 +11,7 @@ use std::fmt;
 use float_cmp::ApproxEq;
 use float_cmp::Ulps;
 
+use reflection;
 use Predicate;
 
 /// Predicate that ensures two numbers are "close" enough, understanding that rounding errors
@@ -85,6 +86,8 @@ impl Predicate<f64> for IsClosePredicate {
         variable.approx_eq(&self.target, self.epsilon, self.ulps)
     }
 }
+
+impl reflection::PredicateReflection for IsClosePredicate {}
 
 impl fmt::Display for IsClosePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/function.rs
+++ b/src/function.rs
@@ -11,6 +11,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
+use reflection;
 use Predicate;
 
 /// Predicate that wraps a function over a reference that returns a `bool`.
@@ -58,6 +59,12 @@ where
     fn eval(&self, variable: &T) -> bool {
         (self.function)(variable)
     }
+}
+
+impl<F, T> reflection::PredicateReflection for FnPredicate<F, T>
+where
+    F: Fn(&T) -> bool,
+{
 }
 
 impl<F, T> fmt::Display for FnPredicate<F, T>

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -13,6 +13,7 @@ use std::fmt;
 use std::hash::Hash;
 use std::iter::FromIterator;
 
+use reflection;
 use Predicate;
 
 /// Predicate that returns `true` if `variable` is a member of the pre-defined
@@ -82,6 +83,12 @@ where
     fn eval(&self, variable: &T) -> bool {
         self.inner.contains(&variable)
     }
+}
+
+impl<T> reflection::PredicateReflection for InPredicate<T>
+where
+    T: PartialEq + fmt::Debug,
+{
 }
 
 impl<T> fmt::Display for InPredicate<T>
@@ -167,6 +174,12 @@ where
     }
 }
 
+impl<T> reflection::PredicateReflection for OrdInPredicate<T>
+where
+    T: Ord + fmt::Debug,
+{
+}
+
 impl<T> fmt::Display for OrdInPredicate<T>
 where
     T: Ord + fmt::Debug,
@@ -209,6 +222,12 @@ where
     fn eval(&self, variable: &T) -> bool {
         self.inner.contains(&variable)
     }
+}
+
+impl<T> reflection::PredicateReflection for HashableInPredicate<T>
+where
+    T: Hash + Eq + fmt::Debug,
+{
 }
 
 impl<T> fmt::Display for HashableInPredicate<T>

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -30,7 +30,7 @@ pub struct InPredicate<T>
 where
     T: PartialEq + fmt::Debug,
 {
-    inner: Vec<T>,
+    inner: reflection::DebugAdapter<Vec<T>>,
 }
 
 impl<T> InPredicate<T>
@@ -61,9 +61,11 @@ where
     /// assert_eq!(true, predicate_fn.eval("c"));
     /// ```
     pub fn sort(self) -> OrdInPredicate<T> {
-        let mut items = self.inner;
+        let mut items = self.inner.debug;
         items.sort();
-        OrdInPredicate { inner: items }
+        OrdInPredicate {
+            inner: reflection::DebugAdapter::new(items),
+        }
     }
 }
 
@@ -72,7 +74,7 @@ where
     T: PartialEq + fmt::Debug,
 {
     fn eval(&self, variable: &T) -> bool {
-        self.inner.contains(variable)
+        self.inner.debug.contains(variable)
     }
 }
 
@@ -81,7 +83,7 @@ where
     T: PartialEq + fmt::Debug + ?Sized,
 {
     fn eval(&self, variable: &T) -> bool {
-        self.inner.contains(&variable)
+        self.inner.debug.contains(&variable)
     }
 }
 
@@ -89,6 +91,10 @@ impl<T> reflection::PredicateReflection for InPredicate<T>
 where
     T: PartialEq + fmt::Debug,
 {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("values", &self.inner)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<T> fmt::Display for InPredicate<T>
@@ -96,7 +102,7 @@ where
     T: PartialEq + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "var in {:?}", self.inner)
+        write!(f, "var in values")
     }
 }
 
@@ -135,7 +141,7 @@ where
     I: IntoIterator<Item = T>,
 {
     InPredicate {
-        inner: Vec::from_iter(iter),
+        inner: reflection::DebugAdapter::new(Vec::from_iter(iter)),
     }
 }
 
@@ -153,7 +159,7 @@ pub struct OrdInPredicate<T>
 where
     T: Ord + fmt::Debug,
 {
-    inner: Vec<T>,
+    inner: reflection::DebugAdapter<Vec<T>>,
 }
 
 impl<T> Predicate<T> for OrdInPredicate<T>
@@ -161,7 +167,7 @@ where
     T: Ord + fmt::Debug,
 {
     fn eval(&self, variable: &T) -> bool {
-        self.inner.binary_search(variable).is_ok()
+        self.inner.debug.binary_search(variable).is_ok()
     }
 }
 
@@ -170,7 +176,7 @@ where
     T: Ord + fmt::Debug + ?Sized,
 {
     fn eval(&self, variable: &T) -> bool {
-        self.inner.binary_search(&variable).is_ok()
+        self.inner.debug.binary_search(&variable).is_ok()
     }
 }
 
@@ -178,6 +184,10 @@ impl<T> reflection::PredicateReflection for OrdInPredicate<T>
 where
     T: Ord + fmt::Debug,
 {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("values", &self.inner)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<T> fmt::Display for OrdInPredicate<T>
@@ -185,7 +195,7 @@ where
     T: Ord + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "var in {:?}", self.inner)
+        write!(f, "var in values")
     }
 }
 
@@ -203,7 +213,7 @@ pub struct HashableInPredicate<T>
 where
     T: Hash + Eq + fmt::Debug,
 {
-    inner: HashSet<T>,
+    inner: reflection::DebugAdapter<HashSet<T>>,
 }
 
 impl<T> Predicate<T> for HashableInPredicate<T>
@@ -211,7 +221,7 @@ where
     T: Hash + Eq + fmt::Debug,
 {
     fn eval(&self, variable: &T) -> bool {
-        self.inner.contains(variable)
+        self.inner.debug.contains(variable)
     }
 }
 
@@ -220,7 +230,7 @@ where
     T: Hash + Eq + fmt::Debug + ?Sized,
 {
     fn eval(&self, variable: &T) -> bool {
-        self.inner.contains(&variable)
+        self.inner.debug.contains(&variable)
     }
 }
 
@@ -228,6 +238,10 @@ impl<T> reflection::PredicateReflection for HashableInPredicate<T>
 where
     T: Hash + Eq + fmt::Debug,
 {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("values", &self.inner)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<T> fmt::Display for HashableInPredicate<T>
@@ -235,7 +249,7 @@ where
     T: Hash + Eq + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "var in {:?}", self.inner)
+        write!(f, "var in values")
     }
 }
 
@@ -268,6 +282,6 @@ where
     I: IntoIterator<Item = T>,
 {
     HashableInPredicate {
-        inner: HashSet::from_iter(iter),
+        inner: reflection::DebugAdapter::new(HashSet::from_iter(iter)),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@
 //!         *variable == 42
 //!     }
 //! }
+//! impl predicates::reflection::PredicateReflection for IsTheAnswer {}
 //! impl fmt::Display for IsTheAnswer {
 //!     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 //!         write!(f, "var.is_the_answer()")
@@ -101,9 +102,10 @@ extern crate regex;
 pub mod prelude;
 
 mod core;
-pub use core::Predicate;
+pub use core::*;
 mod boxed;
-pub use boxed::BoxPredicate;
+pub use boxed::*;
+pub mod reflection;
 
 // core predicates
 pub mod constant;

--- a/src/name.rs
+++ b/src/name.rs
@@ -43,6 +43,10 @@ where
     M: Predicate<Item>,
     Item: ?Sized,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![reflection::Child::new(self.name, &self.inner)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<M, Item> fmt::Display for NamePredicate<M, Item>

--- a/src/name.rs
+++ b/src/name.rs
@@ -11,6 +11,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
+use reflection;
 use Predicate;
 
 /// Augment an existing predicate with a name.
@@ -35,6 +36,13 @@ where
     fn eval(&self, item: &Item) -> bool {
         self.inner.eval(item)
     }
+}
+
+impl<M, Item> reflection::PredicateReflection for NamePredicate<M, Item>
+where
+    M: Predicate<Item>,
+    Item: ?Sized,
+{
 }
 
 impl<M, Item> fmt::Display for NamePredicate<M, Item>

--- a/src/ord.rs
+++ b/src/ord.rs
@@ -10,6 +10,7 @@
 
 use std::fmt;
 
+use reflection;
 use Predicate;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -63,6 +64,12 @@ where
             EqOps::NotEqual => variable.ne(self.constant),
         }
     }
+}
+
+impl<T> reflection::PredicateReflection for EqPredicate<T>
+where
+    T: fmt::Debug + PartialEq,
+{
 }
 
 impl<T> fmt::Display for EqPredicate<T>
@@ -181,6 +188,12 @@ where
             OrdOps::GreaterThan => variable.gt(self.constant),
         }
     }
+}
+
+impl<T> reflection::PredicateReflection for OrdPredicate<T>
+where
+    T: fmt::Debug + PartialOrd,
+{
 }
 
 impl<T> fmt::Display for OrdPredicate<T>

--- a/src/path/existence.rs
+++ b/src/path/existence.rs
@@ -9,6 +9,7 @@
 use std::fmt;
 use std::path;
 
+use reflection;
 use Predicate;
 
 /// Predicate that checks if a file is present
@@ -24,6 +25,8 @@ impl Predicate<path::Path> for ExistencePredicate {
         path.exists() == self.exists
     }
 }
+
+impl reflection::PredicateReflection for ExistencePredicate {}
 
 impl fmt::Display for ExistencePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/path/fc.rs
+++ b/src/path/fc.rs
@@ -11,6 +11,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::path;
 
+use reflection;
 use Predicate;
 
 fn read_file(path: &path::Path) -> io::Result<Vec<u8>> {
@@ -38,6 +39,12 @@ where
         let buffer = read_file(path)?;
         Ok(self.p.eval(&buffer))
     }
+}
+
+impl<P> reflection::PredicateReflection for FileContentPredicate<P>
+where
+    P: Predicate<[u8]>,
+{
 }
 
 impl<P> fmt::Display for FileContentPredicate<P>

--- a/src/path/fc.rs
+++ b/src/path/fc.rs
@@ -45,6 +45,10 @@ impl<P> reflection::PredicateReflection for FileContentPredicate<P>
 where
     P: Predicate<[u8]>,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![reflection::Child::new("predicate", &self.p)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<P> fmt::Display for FileContentPredicate<P>

--- a/src/path/fs.rs
+++ b/src/path/fs.rs
@@ -11,6 +11,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::path;
 
+use reflection;
 use Predicate;
 
 fn read_file(path: &path::Path) -> io::Result<Vec<u8>> {
@@ -66,6 +67,8 @@ impl Predicate<[u8]> for BinaryFilePredicate {
     }
 }
 
+impl reflection::PredicateReflection for BinaryFilePredicate {}
+
 impl fmt::Display for BinaryFilePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "var is {}", self.path.display())
@@ -119,6 +122,8 @@ impl Predicate<str> for StrFilePredicate {
         self.content == actual
     }
 }
+
+impl reflection::PredicateReflection for StrFilePredicate {}
 
 impl fmt::Display for StrFilePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/path/ft.rs
+++ b/src/path/ft.rs
@@ -11,6 +11,7 @@ use std::fs;
 use std::io;
 use std::path;
 
+use reflection;
 use Predicate;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -93,6 +94,8 @@ impl Predicate<path::Path> for FileTypePredicate {
             .unwrap_or(false)
     }
 }
+
+impl reflection::PredicateReflection for FileTypePredicate {}
 
 impl fmt::Display for FileTypePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/path/ft.rs
+++ b/src/path/ft.rs
@@ -95,7 +95,12 @@ impl Predicate<path::Path> for FileTypePredicate {
     }
 }
 
-impl reflection::PredicateReflection for FileTypePredicate {}
+impl reflection::PredicateReflection for FileTypePredicate {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("follow", &self.follow)];
+        Box::new(params.into_iter())
+    }
+}
 
 impl fmt::Display for FileTypePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/reflection.rs
+++ b/src/reflection.rs
@@ -95,3 +95,38 @@ impl<'a> fmt::Debug for Child<'a> {
         write!(f, "({:?}, {})", self.0, self.1)
     }
 }
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct DebugAdapter<T>
+where
+    T: fmt::Debug,
+{
+    pub(crate) debug: T,
+}
+
+impl<T> DebugAdapter<T>
+where
+    T: fmt::Debug,
+{
+    pub fn new(debug: T) -> Self {
+        Self { debug }
+    }
+}
+
+impl<T> fmt::Display for DebugAdapter<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:#?}", self.debug)
+    }
+}
+
+impl<T> fmt::Debug for DebugAdapter<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.debug.fmt(f)
+    }
+}

--- a/src/reflection.rs
+++ b/src/reflection.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2018 The predicates-rs Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Introspect into the state of a `Predicate`.
+
+use std::fmt;
+
+/// Introspect the state of a `Predicate`.
+pub trait PredicateReflection: fmt::Display {
+    /// Parameters of the current `Predicate`.
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = Parameter<'a>> + 'a> {
+        let params = vec![];
+        Box::new(params.into_iter())
+    }
+
+    /// Nested `Predicate`s of the current `Predicate`.
+    fn children<'a>(&'a self) -> Box<Iterator<Item = Child<'a>> + 'a> {
+        let params = vec![];
+        Box::new(params.into_iter())
+    }
+}
+
+/// A view of a `Predicate` parameter, provided by reflection.
+///
+/// ```rust
+/// use predicates;
+///
+/// let param = predicates::reflection::Parameter::new("key", &10);
+/// println!("{}", param);
+/// ```
+pub struct Parameter<'a>(&'a str, &'a fmt::Display);
+
+impl<'a> Parameter<'a> {
+    /// Create a new `Parameter`.
+    pub fn new(key: &'a str, value: &'a fmt::Display) -> Self {
+        Self { 0: key, 1: value }
+    }
+
+    /// Access the `Parameter` name.
+    pub fn name(&self) -> &str {
+        self.0
+    }
+
+    /// Access the `Parameter` value.
+    pub fn value(&self) -> &fmt::Display {
+        self.1
+    }
+}
+
+impl<'a> fmt::Display for Parameter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}", self.0, self.1)
+    }
+}
+
+impl<'a> fmt::Debug for Parameter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({:?}, {})", self.0, self.1)
+    }
+}
+
+/// A view of a `Predicate` child, provided by reflection.
+pub struct Child<'a>(&'a str, &'a PredicateReflection);
+
+impl<'a> Child<'a> {
+    /// Create a new `Predicate` child.
+    pub fn new(key: &'a str, value: &'a PredicateReflection) -> Self {
+        Self { 0: key, 1: value }
+    }
+
+    /// Access the `Child`'s name.
+    pub fn name(&self) -> &str {
+        self.0
+    }
+
+    /// Access the `Child` `Predicate`.
+    pub fn value(&self) -> &PredicateReflection {
+        self.1
+    }
+}
+
+impl<'a> fmt::Display for Child<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}", self.0, self.1)
+    }
+}
+
+impl<'a> fmt::Debug for Child<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({:?}, {})", self.0, self.1)
+    }
+}

--- a/src/str/adapters.rs
+++ b/src/str/adapters.rs
@@ -29,6 +29,10 @@ impl<P> reflection::PredicateReflection for TrimPredicate<P>
 where
     P: Predicate<str>,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![reflection::Child::new("predicate", &self.p)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<P> fmt::Display for TrimPredicate<P>
@@ -75,6 +79,10 @@ impl<P> reflection::PredicateReflection for Utf8Predicate<P>
 where
     P: Predicate<str>,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![reflection::Child::new("predicate", &self.p)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<P> fmt::Display for Utf8Predicate<P>

--- a/src/str/adapters.rs
+++ b/src/str/adapters.rs
@@ -2,6 +2,7 @@ use std::ffi;
 use std::fmt;
 use std::str;
 
+use reflection;
 use Predicate;
 
 /// Predicate adaper that trims the variable being tested.
@@ -22,6 +23,12 @@ where
     fn eval(&self, variable: &str) -> bool {
         self.p.eval(variable.trim())
     }
+}
+
+impl<P> reflection::PredicateReflection for TrimPredicate<P>
+where
+    P: Predicate<str>,
+{
 }
 
 impl<P> fmt::Display for TrimPredicate<P>
@@ -62,6 +69,12 @@ where
             .map(|s| self.p.eval(s))
             .unwrap_or(false)
     }
+}
+
+impl<P> reflection::PredicateReflection for Utf8Predicate<P>
+where
+    P: Predicate<str>,
+{
 }
 
 impl<P> fmt::Display for Utf8Predicate<P>

--- a/src/str/basics.rs
+++ b/src/str/basics.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+use reflection;
 use Predicate;
 
 /// Predicate that checks for empty strings.
@@ -21,6 +22,8 @@ impl Predicate<str> for IsEmptyPredicate {
         variable.is_empty()
     }
 }
+
+impl reflection::PredicateReflection for IsEmptyPredicate {}
 
 impl fmt::Display for IsEmptyPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -56,6 +59,8 @@ impl Predicate<str> for StartsWithPredicate {
         variable.starts_with(&self.pattern)
     }
 }
+
+impl reflection::PredicateReflection for StartsWithPredicate {}
 
 impl fmt::Display for StartsWithPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -96,6 +101,8 @@ impl Predicate<str> for EndsWithPredicate {
         variable.ends_with(&self.pattern)
     }
 }
+
+impl reflection::PredicateReflection for EndsWithPredicate {}
 
 impl fmt::Display for EndsWithPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -157,6 +164,8 @@ impl Predicate<str> for ContainsPredicate {
     }
 }
 
+impl reflection::PredicateReflection for ContainsPredicate {}
+
 impl fmt::Display for ContainsPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "var.contains({:?})", self.pattern)
@@ -177,6 +186,8 @@ impl Predicate<str> for MatchesPredicate {
         variable.matches(&self.pattern).count() == self.count
     }
 }
+
+impl reflection::PredicateReflection for MatchesPredicate {}
 
 impl fmt::Display for MatchesPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/str/basics.rs
+++ b/src/str/basics.rs
@@ -187,11 +187,16 @@ impl Predicate<str> for MatchesPredicate {
     }
 }
 
-impl reflection::PredicateReflection for MatchesPredicate {}
+impl reflection::PredicateReflection for MatchesPredicate {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("count", &self.count)];
+        Box::new(params.into_iter())
+    }
+}
 
 impl fmt::Display for MatchesPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "var.contains({:?}, {})", self.pattern, self.count)
+        write!(f, "var.contains({})", self.pattern)
     }
 }
 

--- a/src/str/difference.rs
+++ b/src/str/difference.rs
@@ -11,6 +11,7 @@ use std::fmt;
 
 use difference;
 
+use reflection;
 use Predicate;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -91,6 +92,8 @@ impl Predicate<str> for DifferencePredicate {
         self.op.eval(self.distance, change.distance)
     }
 }
+
+impl reflection::PredicateReflection for DifferencePredicate {}
 
 impl fmt::Display for DifferencePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/str/difference.rs
+++ b/src/str/difference.rs
@@ -93,13 +93,18 @@ impl Predicate<str> for DifferencePredicate {
     }
 }
 
-impl reflection::PredicateReflection for DifferencePredicate {}
+impl reflection::PredicateReflection for DifferencePredicate {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("original", &self.orig)];
+        Box::new(params.into_iter())
+    }
+}
 
 impl fmt::Display for DifferencePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.op {
-            DistanceOp::Similar => write!(f, "var - {:?} <= {}", self.orig, self.distance),
-            DistanceOp::Different => write!(f, "{} < var - {:?}", self.distance, self.orig),
+            DistanceOp::Similar => write!(f, "var - original <= {}", self.distance),
+            DistanceOp::Different => write!(f, "{} < var - original", self.distance),
         }
     }
 }

--- a/src/str/regex.rs
+++ b/src/str/regex.rs
@@ -10,6 +10,7 @@ use std::fmt;
 
 use regex;
 
+use reflection;
 use Predicate;
 
 /// An error that occurred during parsing or compiling a regular expression.
@@ -46,6 +47,8 @@ impl Predicate<str> for RegexPredicate {
     }
 }
 
+impl reflection::PredicateReflection for RegexPredicate {}
+
 impl fmt::Display for RegexPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "var.is_match({})", self.re)
@@ -66,6 +69,8 @@ impl Predicate<str> for RegexMatchesPredicate {
         self.re.find_iter(variable).count() == self.count
     }
 }
+
+impl reflection::PredicateReflection for RegexMatchesPredicate {}
 
 impl fmt::Display for RegexMatchesPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/str/regex.rs
+++ b/src/str/regex.rs
@@ -70,11 +70,16 @@ impl Predicate<str> for RegexMatchesPredicate {
     }
 }
 
-impl reflection::PredicateReflection for RegexMatchesPredicate {}
+impl reflection::PredicateReflection for RegexMatchesPredicate {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("count", &self.count)];
+        Box::new(params.into_iter())
+    }
+}
 
 impl fmt::Display for RegexMatchesPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "var.is_match({}).count({})", self.re, self.count)
+        write!(f, "var.is_match({})", self.re)
     }
 }
 


### PR DESCRIPTION
Predicates can now report parameter details that don't show up in
`Display` as well as what children they have.  The expectation is that
this will be used by the solution for #7.

BREAKING CHANGE: `Predicate`s must also implement
`reflection::PredicateReflection`.

<!--
Quick reminders:
- Were tests written?
- Is commit history clean?
- Were copyright statements updated?
-->
