### PR TITLE
A way to display *why* a predicate failed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,9 @@ difference = { version = "2.0", optional = true }
 normalize-line-endings = { version = "0.2.2", optional = true }
 regex = { version="1.0", optional = true }
 float-cmp = { version="0.4", optional = true }
+treeline = { version = "0.1", optional = true }
 
 [features]
-default = ["difference", "regex", "float-cmp", "normalize-line-endings"]
+default = ["difference", "regex", "float-cmp", "normalize-line-endings", "tree"]
 unstable = []
+tree = ["treeline",]

--- a/examples/case_tree.rs
+++ b/examples/case_tree.rs
@@ -1,0 +1,15 @@
+extern crate predicates;
+
+use predicates::prelude::*;
+use predicates::tree::CaseTreeExt;
+
+fn main() {
+    let pred = predicate::ne(5).not().and(predicate::ge(5));
+
+    let var = 5;
+    let case = pred.find_case(true, &var);
+    if let Some(case) = case {
+        println!("var is {}", var);
+        println!("{}", case.tree());
+    }
+}

--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -54,6 +54,24 @@ where
     fn eval(&self, item: &Item) -> bool {
         self.a.eval(item) && self.b.eval(item)
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &Item) -> Option<reflection::Case<'a>> {
+        let child_a = self.a.find_case(expected, variable);
+        match (expected, child_a) {
+            (true, Some(child_a)) => self.b.find_case(expected, variable).map(|child_b| {
+                reflection::Case::new(Some(self), expected)
+                    .add_child(child_a)
+                    .add_child(child_b)
+            }),
+            (true, None) => None,
+            (false, Some(child_a)) => {
+                Some(reflection::Case::new(Some(self), expected).add_child(child_a))
+            }
+            (false, None) => self.b
+                .find_case(expected, variable)
+                .map(|child_b| reflection::Case::new(Some(self), expected).add_child(child_b)),
+        }
+    }
 }
 
 impl<M1, M2, Item> reflection::PredicateReflection for AndPredicate<M1, M2, Item>
@@ -79,6 +97,91 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({} && {})", self.a, self.b)
+    }
+}
+
+#[cfg(test)]
+mod test_and {
+    use prelude::*;
+
+    #[test]
+    fn find_case_true() {
+        assert!(
+            predicate::always()
+                .and(predicate::always())
+                .find_case(true, &5)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn find_case_true_left_fail() {
+        assert!(
+            predicate::never()
+                .and(predicate::always())
+                .find_case(true, &5)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn find_case_true_right_fail() {
+        assert!(
+            predicate::always()
+                .and(predicate::never())
+                .find_case(true, &5)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn find_case_true_fails() {
+        assert!(
+            predicate::never()
+                .and(predicate::never())
+                .find_case(true, &5)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn find_case_false() {
+        assert!(
+            predicate::never()
+                .and(predicate::never())
+                .find_case(false, &5)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn find_case_false_fails() {
+        assert!(
+            predicate::always()
+                .and(predicate::always())
+                .find_case(false, &5)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn find_case_false_left_fail() {
+        assert!(
+            predicate::never()
+                .and(predicate::always())
+                .find_case(false, &5)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn find_case_false_right_fail() {
+        assert!(
+            predicate::always()
+                .and(predicate::never())
+                .find_case(false, &5)
+                .is_some()
+        );
     }
 }
 
@@ -122,6 +225,24 @@ where
     fn eval(&self, item: &Item) -> bool {
         self.a.eval(item) || self.b.eval(item)
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &Item) -> Option<reflection::Case<'a>> {
+        let child_a = self.a.find_case(expected, variable);
+        match (expected, child_a) {
+            (true, Some(child_a)) => {
+                Some(reflection::Case::new(Some(self), expected).add_child(child_a))
+            }
+            (true, None) => self.b
+                .find_case(expected, variable)
+                .map(|child_b| reflection::Case::new(Some(self), expected).add_child(child_b)),
+            (false, Some(child_a)) => self.b.find_case(expected, variable).map(|child_b| {
+                reflection::Case::new(Some(self), expected)
+                    .add_child(child_a)
+                    .add_child(child_b)
+            }),
+            (false, None) => None,
+        }
+    }
 }
 
 impl<M1, M2, Item> reflection::PredicateReflection for OrPredicate<M1, M2, Item>
@@ -147,6 +268,91 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({} || {})", self.a, self.b)
+    }
+}
+
+#[cfg(test)]
+mod test_or {
+    use prelude::*;
+
+    #[test]
+    fn find_case_true() {
+        assert!(
+            predicate::always()
+                .or(predicate::always())
+                .find_case(true, &5)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn find_case_true_left_fail() {
+        assert!(
+            predicate::never()
+                .or(predicate::always())
+                .find_case(true, &5)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn find_case_true_right_fail() {
+        assert!(
+            predicate::always()
+                .or(predicate::never())
+                .find_case(true, &5)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn find_case_true_fails() {
+        assert!(
+            predicate::never()
+                .or(predicate::never())
+                .find_case(true, &5)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn find_case_false() {
+        assert!(
+            predicate::never()
+                .or(predicate::never())
+                .find_case(false, &5)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn find_case_false_fails() {
+        assert!(
+            predicate::always()
+                .or(predicate::always())
+                .find_case(false, &5)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn find_case_false_left_fail() {
+        assert!(
+            predicate::never()
+                .or(predicate::always())
+                .find_case(false, &5)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn find_case_false_right_fail() {
+        assert!(
+            predicate::always()
+                .or(predicate::never())
+                .find_case(false, &5)
+                .is_none()
+        );
     }
 }
 
@@ -184,6 +390,12 @@ where
 {
     fn eval(&self, item: &Item) -> bool {
         !self.inner.eval(item)
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &Item) -> Option<reflection::Case<'a>> {
+        self.inner
+            .find_case(!expected, variable)
+            .map(|child| reflection::Case::new(Some(self), expected).add_child(child))
     }
 }
 

--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -62,6 +62,13 @@ where
     M2: Predicate<Item>,
     Item: ?Sized,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![
+            reflection::Child::new("left", &self.a),
+            reflection::Child::new("right", &self.b),
+        ];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<M1, M2, Item> fmt::Display for AndPredicate<M1, M2, Item>
@@ -123,6 +130,13 @@ where
     M2: Predicate<Item>,
     Item: ?Sized,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![
+            reflection::Child::new("left", &self.a),
+            reflection::Child::new("right", &self.b),
+        ];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<M1, M2, Item> fmt::Display for OrPredicate<M1, M2, Item>
@@ -178,6 +192,10 @@ where
     M: Predicate<Item>,
     Item: ?Sized,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![reflection::Child::new("predicate", &self.inner)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<M, Item> fmt::Display for NotPredicate<M, Item>

--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -11,6 +11,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
+use reflection;
 use Predicate;
 
 /// Predicate that combines two `Predicate`s, returning the AND of the results.
@@ -53,6 +54,14 @@ where
     fn eval(&self, item: &Item) -> bool {
         self.a.eval(item) && self.b.eval(item)
     }
+}
+
+impl<M1, M2, Item> reflection::PredicateReflection for AndPredicate<M1, M2, Item>
+where
+    M1: Predicate<Item>,
+    M2: Predicate<Item>,
+    Item: ?Sized,
+{
 }
 
 impl<M1, M2, Item> fmt::Display for AndPredicate<M1, M2, Item>
@@ -108,6 +117,14 @@ where
     }
 }
 
+impl<M1, M2, Item> reflection::PredicateReflection for OrPredicate<M1, M2, Item>
+where
+    M1: Predicate<Item>,
+    M2: Predicate<Item>,
+    Item: ?Sized,
+{
+}
+
 impl<M1, M2, Item> fmt::Display for OrPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
@@ -154,6 +171,13 @@ where
     fn eval(&self, item: &Item) -> bool {
         !self.inner.eval(item)
     }
+}
+
+impl<M, Item> reflection::PredicateReflection for NotPredicate<M, Item>
+where
+    M: Predicate<Item>,
+    Item: ?Sized,
+{
 }
 
 impl<M, Item> fmt::Display for NotPredicate<M, Item>

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -11,6 +11,7 @@
 
 use std::fmt;
 
+use core;
 use reflection;
 use Predicate;
 
@@ -69,6 +70,10 @@ where
 {
     fn eval(&self, variable: &Item) -> bool {
         self.0.eval(variable)
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &Item) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -11,6 +11,7 @@
 
 use std::fmt;
 
+use reflection;
 use Predicate;
 
 /// `Predicate` that wraps another `Predicate` as a trait object, allowing
@@ -38,6 +39,12 @@ where
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BoxPredicate").finish()
     }
+}
+
+impl<Item> reflection::PredicateReflection for BoxPredicate<Item>
+where
+    Item: ?Sized,
+{
 }
 
 impl<Item> fmt::Display for BoxPredicate<Item>

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -45,6 +45,13 @@ impl<Item> reflection::PredicateReflection for BoxPredicate<Item>
 where
     Item: ?Sized,
 {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        self.0.parameters()
+    }
+
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        self.0.children()
+    }
 }
 
 impl<Item> fmt::Display for BoxPredicate<Item>

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -11,6 +11,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
+use core;
 use reflection;
 use Predicate;
 
@@ -26,6 +27,10 @@ pub struct BooleanPredicate<Item> {
 impl<Item> Predicate<Item> for BooleanPredicate<Item> {
     fn eval(&self, _variable: &Item) -> bool {
         self.retval
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &Item) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -29,7 +29,12 @@ impl<Item> Predicate<Item> for BooleanPredicate<Item> {
     }
 }
 
-impl<Item> reflection::PredicateReflection for BooleanPredicate<Item> {}
+impl<Item> reflection::PredicateReflection for BooleanPredicate<Item> {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("value", &self.retval)];
+        Box::new(params.into_iter())
+    }
+}
 
 impl<Item> fmt::Display for BooleanPredicate<Item> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -11,6 +11,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
+use reflection;
 use Predicate;
 
 /// Predicate that always returns a constant (boolean) result.
@@ -27,6 +28,8 @@ impl<Item> Predicate<Item> for BooleanPredicate<Item> {
         self.retval
     }
 }
+
+impl<Item> reflection::PredicateReflection for BooleanPredicate<Item> {}
 
 impl<Item> fmt::Display for BooleanPredicate<Item> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/core.rs
+++ b/src/core.rs
@@ -21,15 +21,29 @@ pub trait Predicate<Item: ?Sized>: reflection::PredicateReflection {
     fn eval(&self, variable: &Item) -> bool;
 
     /// Find a case that proves this predicate as `expected` when run against `variable`.
-    fn find_case<'a>(&'a self, expected: bool, variable: &Item) -> Option<reflection::Case<'a>>
-    where
-        Self: Sized,
-    {
+    fn find_case<'a>(&'a self, expected: bool, variable: &Item) -> Option<reflection::Case<'a>> {
         let actual = self.eval(variable);
         if expected == actual {
-            Some(reflection::Case::new(Some(self), actual))
+            Some(reflection::Case::new(None, actual))
         } else {
             None
         }
+    }
+}
+
+pub(crate) fn default_find_case<'a, P, Item>(
+    pred: &'a P,
+    expected: bool,
+    variable: &Item,
+) -> Option<reflection::Case<'a>>
+where
+    P: Predicate<Item>,
+    Item: ?Sized,
+{
+    let actual = pred.eval(variable);
+    if expected == actual {
+        Some(reflection::Case::new(Some(pred), actual))
+    } else {
+        None
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -19,4 +19,17 @@ pub trait Predicate<Item: ?Sized>: reflection::PredicateReflection {
     /// Execute this `Predicate` against `variable`, returning the resulting
     /// boolean.
     fn eval(&self, variable: &Item) -> bool;
+
+    /// Find a case that proves this predicate as `expected` when run against `variable`.
+    fn find_case<'a>(&'a self, expected: bool, variable: &Item) -> Option<reflection::Case<'a>>
+    where
+        Self: Sized,
+    {
+        let actual = self.eval(variable);
+        if expected == actual {
+            Some(reflection::Case::new(Some(self), actual))
+        } else {
+            None
+        }
+    }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt;
+use reflection;
 
 /// Trait for generically evaluating a type against a dynamically created
 /// predicate function.
@@ -15,7 +15,7 @@ use std::fmt;
 /// mean that the evaluated item is in some sort of pre-defined set.  This is
 /// different from `Ord` and `Eq` in that an `item` will almost never be the
 /// same type as the implementing `Predicate` type.
-pub trait Predicate<Item: ?Sized>: fmt::Display {
+pub trait Predicate<Item: ?Sized>: reflection::PredicateReflection {
     /// Execute this `Predicate` against `variable`, returning the resulting
     /// boolean.
     fn eval(&self, variable: &Item) -> bool;

--- a/src/float/close.rs
+++ b/src/float/close.rs
@@ -85,6 +85,25 @@ impl Predicate<f64> for IsClosePredicate {
     fn eval(&self, variable: &f64) -> bool {
         variable.approx_eq(&self.target, self.epsilon, self.ulps)
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &f64) -> Option<reflection::Case<'a>> {
+        let actual = self.eval(variable);
+        if expected == actual {
+            Some(
+                reflection::Case::new(Some(self), actual)
+                    .add_product(reflection::Product::new(
+                        "actual epsilon",
+                        (variable - self.target).abs(),
+                    ))
+                    .add_product(reflection::Product::new(
+                        "actual ulps",
+                        variable.ulps(&self.target).abs(),
+                    )),
+            )
+        } else {
+            None
+        }
+    }
 }
 
 impl reflection::PredicateReflection for IsClosePredicate {

--- a/src/float/close.rs
+++ b/src/float/close.rs
@@ -87,15 +87,19 @@ impl Predicate<f64> for IsClosePredicate {
     }
 }
 
-impl reflection::PredicateReflection for IsClosePredicate {}
+impl reflection::PredicateReflection for IsClosePredicate {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![
+            reflection::Parameter::new("epsilon", &self.epsilon),
+            reflection::Parameter::new("ulps", &self.ulps),
+        ];
+        Box::new(params.into_iter())
+    }
+}
 
 impl fmt::Display for IsClosePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "var ~= {} +/- {} ({})",
-            self.target, self.epsilon, self.ulps
-        )
+        write!(f, "var ~= {}", self.target)
     }
 }
 

--- a/src/float/close.rs
+++ b/src/float/close.rs
@@ -11,6 +11,7 @@ use std::fmt;
 use float_cmp::ApproxEq;
 use float_cmp::Ulps;
 
+use reflection;
 use Predicate;
 
 /// Predicate that ensures two numbers are "close" enough, understanding that rounding errors
@@ -85,6 +86,8 @@ impl Predicate<f64> for IsClosePredicate {
         variable.approx_eq(&self.target, self.epsilon, self.ulps)
     }
 }
+
+impl reflection::PredicateReflection for IsClosePredicate {}
 
 impl fmt::Display for IsClosePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/function.rs
+++ b/src/function.rs
@@ -11,6 +11,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
+use core;
 use reflection;
 use Predicate;
 
@@ -61,6 +62,10 @@ where
 {
     fn eval(&self, variable: &T) -> bool {
         (self.function)(variable)
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &T) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -11,6 +11,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
+use reflection;
 use Predicate;
 
 /// Predicate that wraps a function over a reference that returns a `bool`.
@@ -61,6 +62,13 @@ where
     fn eval(&self, variable: &T) -> bool {
         (self.function)(variable)
     }
+}
+
+impl<F, T> reflection::PredicateReflection for FnPredicate<F, T>
+where
+    F: Fn(&T) -> bool,
+    T: ?Sized,
+{
 }
 
 impl<F, T> fmt::Display for FnPredicate<F, T>

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -13,6 +13,7 @@ use std::fmt;
 use std::hash::Hash;
 use std::iter::FromIterator;
 
+use core;
 use reflection;
 use Predicate;
 
@@ -76,6 +77,10 @@ where
     fn eval(&self, variable: &T) -> bool {
         self.inner.debug.contains(variable)
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &T) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
+    }
 }
 
 impl<'a, T> Predicate<T> for InPredicate<&'a T>
@@ -84,6 +89,10 @@ where
 {
     fn eval(&self, variable: &T) -> bool {
         self.inner.debug.contains(&variable)
+    }
+
+    fn find_case<'b>(&'b self, expected: bool, variable: &T) -> Option<reflection::Case<'b>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 
@@ -169,6 +178,10 @@ where
     fn eval(&self, variable: &T) -> bool {
         self.inner.debug.binary_search(variable).is_ok()
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &T) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
+    }
 }
 
 impl<'a, T> Predicate<T> for OrdInPredicate<&'a T>
@@ -177,6 +190,10 @@ where
 {
     fn eval(&self, variable: &T) -> bool {
         self.inner.debug.binary_search(&variable).is_ok()
+    }
+
+    fn find_case<'b>(&'b self, expected: bool, variable: &T) -> Option<reflection::Case<'b>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 
@@ -223,6 +240,10 @@ where
     fn eval(&self, variable: &T) -> bool {
         self.inner.debug.contains(variable)
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &T) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
+    }
 }
 
 impl<'a, T> Predicate<T> for HashableInPredicate<&'a T>
@@ -231,6 +252,10 @@ where
 {
     fn eval(&self, variable: &T) -> bool {
         self.inner.debug.contains(&variable)
+    }
+
+    fn find_case<'b>(&'b self, expected: bool, variable: &T) -> Option<reflection::Case<'b>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -13,6 +13,7 @@ use std::fmt;
 use std::hash::Hash;
 use std::iter::FromIterator;
 
+use reflection;
 use Predicate;
 
 /// Predicate that returns `true` if `variable` is a member of the pre-defined
@@ -82,6 +83,12 @@ where
     fn eval(&self, variable: &T) -> bool {
         self.inner.contains(&variable)
     }
+}
+
+impl<T> reflection::PredicateReflection for InPredicate<T>
+where
+    T: PartialEq + fmt::Debug,
+{
 }
 
 impl<T> fmt::Display for InPredicate<T>
@@ -167,6 +174,12 @@ where
     }
 }
 
+impl<T> reflection::PredicateReflection for OrdInPredicate<T>
+where
+    T: Ord + fmt::Debug,
+{
+}
+
 impl<T> fmt::Display for OrdInPredicate<T>
 where
     T: Ord + fmt::Debug,
@@ -209,6 +222,12 @@ where
     fn eval(&self, variable: &T) -> bool {
         self.inner.contains(&variable)
     }
+}
+
+impl<T> reflection::PredicateReflection for HashableInPredicate<T>
+where
+    T: Hash + Eq + fmt::Debug,
+{
 }
 
 impl<T> fmt::Display for HashableInPredicate<T>

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -30,7 +30,7 @@ pub struct InPredicate<T>
 where
     T: PartialEq + fmt::Debug,
 {
-    inner: Vec<T>,
+    inner: reflection::DebugAdapter<Vec<T>>,
 }
 
 impl<T> InPredicate<T>
@@ -61,9 +61,11 @@ where
     /// assert_eq!(true, predicate_fn.eval("c"));
     /// ```
     pub fn sort(self) -> OrdInPredicate<T> {
-        let mut items = self.inner;
+        let mut items = self.inner.debug;
         items.sort();
-        OrdInPredicate { inner: items }
+        OrdInPredicate {
+            inner: reflection::DebugAdapter::new(items),
+        }
     }
 }
 
@@ -72,7 +74,7 @@ where
     T: PartialEq + fmt::Debug,
 {
     fn eval(&self, variable: &T) -> bool {
-        self.inner.contains(variable)
+        self.inner.debug.contains(variable)
     }
 }
 
@@ -81,7 +83,7 @@ where
     T: PartialEq + fmt::Debug + ?Sized,
 {
     fn eval(&self, variable: &T) -> bool {
-        self.inner.contains(&variable)
+        self.inner.debug.contains(&variable)
     }
 }
 
@@ -89,6 +91,10 @@ impl<T> reflection::PredicateReflection for InPredicate<T>
 where
     T: PartialEq + fmt::Debug,
 {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("values", &self.inner)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<T> fmt::Display for InPredicate<T>
@@ -96,7 +102,7 @@ where
     T: PartialEq + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "var in {:?}", self.inner)
+        write!(f, "var in values")
     }
 }
 
@@ -135,7 +141,7 @@ where
     I: IntoIterator<Item = T>,
 {
     InPredicate {
-        inner: Vec::from_iter(iter),
+        inner: reflection::DebugAdapter::new(Vec::from_iter(iter)),
     }
 }
 
@@ -153,7 +159,7 @@ pub struct OrdInPredicate<T>
 where
     T: Ord + fmt::Debug,
 {
-    inner: Vec<T>,
+    inner: reflection::DebugAdapter<Vec<T>>,
 }
 
 impl<T> Predicate<T> for OrdInPredicate<T>
@@ -161,7 +167,7 @@ where
     T: Ord + fmt::Debug,
 {
     fn eval(&self, variable: &T) -> bool {
-        self.inner.binary_search(variable).is_ok()
+        self.inner.debug.binary_search(variable).is_ok()
     }
 }
 
@@ -170,7 +176,7 @@ where
     T: Ord + fmt::Debug + ?Sized,
 {
     fn eval(&self, variable: &T) -> bool {
-        self.inner.binary_search(&variable).is_ok()
+        self.inner.debug.binary_search(&variable).is_ok()
     }
 }
 
@@ -178,6 +184,10 @@ impl<T> reflection::PredicateReflection for OrdInPredicate<T>
 where
     T: Ord + fmt::Debug,
 {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("values", &self.inner)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<T> fmt::Display for OrdInPredicate<T>
@@ -185,7 +195,7 @@ where
     T: Ord + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "var in {:?}", self.inner)
+        write!(f, "var in values")
     }
 }
 
@@ -203,7 +213,7 @@ pub struct HashableInPredicate<T>
 where
     T: Hash + Eq + fmt::Debug,
 {
-    inner: HashSet<T>,
+    inner: reflection::DebugAdapter<HashSet<T>>,
 }
 
 impl<T> Predicate<T> for HashableInPredicate<T>
@@ -211,7 +221,7 @@ where
     T: Hash + Eq + fmt::Debug,
 {
     fn eval(&self, variable: &T) -> bool {
-        self.inner.contains(variable)
+        self.inner.debug.contains(variable)
     }
 }
 
@@ -220,7 +230,7 @@ where
     T: Hash + Eq + fmt::Debug + ?Sized,
 {
     fn eval(&self, variable: &T) -> bool {
-        self.inner.contains(&variable)
+        self.inner.debug.contains(&variable)
     }
 }
 
@@ -228,6 +238,10 @@ impl<T> reflection::PredicateReflection for HashableInPredicate<T>
 where
     T: Hash + Eq + fmt::Debug,
 {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("values", &self.inner)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<T> fmt::Display for HashableInPredicate<T>
@@ -235,7 +249,7 @@ where
     T: Hash + Eq + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "var in {:?}", self.inner)
+        write!(f, "var in values")
     }
 }
 
@@ -268,6 +282,6 @@ where
     I: IntoIterator<Item = T>,
 {
     HashableInPredicate {
-        inner: HashSet::from_iter(iter),
+        inner: reflection::DebugAdapter::new(HashSet::from_iter(iter)),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@
 //!         *variable == 42
 //!     }
 //! }
+//! impl predicates::reflection::PredicateReflection for IsTheAnswer {}
 //! impl fmt::Display for IsTheAnswer {
 //!     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 //!         write!(f, "var.is_the_answer()")
@@ -103,9 +104,10 @@ extern crate regex;
 pub mod prelude;
 
 mod core;
-pub use core::Predicate;
+pub use core::*;
 mod boxed;
-pub use boxed::BoxPredicate;
+pub use boxed::*;
+pub mod reflection;
 
 // core predicates
 pub mod constant;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,8 @@ extern crate float_cmp;
 extern crate normalize_line_endings;
 #[cfg(feature = "regex")]
 extern crate regex;
+#[cfg(feature = "treeline")]
+extern crate treeline;
 
 pub mod prelude;
 
@@ -123,3 +125,5 @@ pub mod boolean;
 pub mod float;
 pub mod path;
 pub mod str;
+#[cfg(feature = "tree")]
+pub mod tree;

--- a/src/name.rs
+++ b/src/name.rs
@@ -36,6 +36,10 @@ where
     fn eval(&self, item: &Item) -> bool {
         self.inner.eval(item)
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &Item) -> Option<reflection::Case<'a>> {
+        self.inner.find_case(expected, variable)
+    }
 }
 
 impl<M, Item> reflection::PredicateReflection for NamePredicate<M, Item>

--- a/src/name.rs
+++ b/src/name.rs
@@ -43,6 +43,10 @@ where
     M: Predicate<Item>,
     Item: ?Sized,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![reflection::Child::new(self.name, &self.inner)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<M, Item> fmt::Display for NamePredicate<M, Item>

--- a/src/name.rs
+++ b/src/name.rs
@@ -11,6 +11,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
+use reflection;
 use Predicate;
 
 /// Augment an existing predicate with a name.
@@ -35,6 +36,13 @@ where
     fn eval(&self, item: &Item) -> bool {
         self.inner.eval(item)
     }
+}
+
+impl<M, Item> reflection::PredicateReflection for NamePredicate<M, Item>
+where
+    M: Predicate<Item>,
+    Item: ?Sized,
+{
 }
 
 impl<M, Item> fmt::Display for NamePredicate<M, Item>

--- a/src/ord.rs
+++ b/src/ord.rs
@@ -10,6 +10,7 @@
 
 use std::fmt;
 
+use core;
 use reflection;
 use Predicate;
 
@@ -52,6 +53,10 @@ where
             EqOps::NotEqual => variable.ne(&self.constant),
         }
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &T) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
+    }
 }
 
 impl<'a, T> Predicate<T> for EqPredicate<&'a T>
@@ -63,6 +68,10 @@ where
             EqOps::Equal => variable.eq(self.constant),
             EqOps::NotEqual => variable.ne(self.constant),
         }
+    }
+
+    fn find_case<'b>(&'b self, expected: bool, variable: &T) -> Option<reflection::Case<'b>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 
@@ -174,6 +183,10 @@ where
             OrdOps::GreaterThan => variable.gt(&self.constant),
         }
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &T) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
+    }
 }
 
 impl<'a, T> Predicate<T> for OrdPredicate<&'a T>
@@ -187,6 +200,10 @@ where
             OrdOps::GreaterThanOrEqual => variable.ge(self.constant),
             OrdOps::GreaterThan => variable.gt(self.constant),
         }
+    }
+
+    fn find_case<'b>(&'b self, expected: bool, variable: &T) -> Option<reflection::Case<'b>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 

--- a/src/ord.rs
+++ b/src/ord.rs
@@ -10,6 +10,7 @@
 
 use std::fmt;
 
+use reflection;
 use Predicate;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -63,6 +64,12 @@ where
             EqOps::NotEqual => variable.ne(self.constant),
         }
     }
+}
+
+impl<T> reflection::PredicateReflection for EqPredicate<T>
+where
+    T: fmt::Debug + PartialEq,
+{
 }
 
 impl<T> fmt::Display for EqPredicate<T>
@@ -181,6 +188,12 @@ where
             OrdOps::GreaterThan => variable.gt(self.constant),
         }
     }
+}
+
+impl<T> reflection::PredicateReflection for OrdPredicate<T>
+where
+    T: fmt::Debug + PartialOrd,
+{
 }
 
 impl<T> fmt::Display for OrdPredicate<T>

--- a/src/path/existence.rs
+++ b/src/path/existence.rs
@@ -9,6 +9,7 @@
 use std::fmt;
 use std::path;
 
+use core;
 use reflection;
 use Predicate;
 
@@ -23,6 +24,14 @@ pub struct ExistencePredicate {
 impl Predicate<path::Path> for ExistencePredicate {
     fn eval(&self, path: &path::Path) -> bool {
         path.exists() == self.exists
+    }
+
+    fn find_case<'a>(
+        &'a self,
+        expected: bool,
+        variable: &path::Path,
+    ) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 

--- a/src/path/existence.rs
+++ b/src/path/existence.rs
@@ -9,6 +9,7 @@
 use std::fmt;
 use std::path;
 
+use reflection;
 use Predicate;
 
 /// Predicate that checks if a file is present
@@ -24,6 +25,8 @@ impl Predicate<path::Path> for ExistencePredicate {
         path.exists() == self.exists
     }
 }
+
+impl reflection::PredicateReflection for ExistencePredicate {}
 
 impl fmt::Display for ExistencePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/path/fc.rs
+++ b/src/path/fc.rs
@@ -67,6 +67,24 @@ where
     fn eval(&self, path: &path::Path) -> bool {
         self.eval(path).unwrap_or(false)
     }
+
+    fn find_case<'a>(
+        &'a self,
+        expected: bool,
+        variable: &path::Path,
+    ) -> Option<reflection::Case<'a>> {
+        let buffer = read_file(variable);
+        match (expected, buffer) {
+            (_, Ok(buffer)) => self.p
+                .find_case(expected, &buffer)
+                .map(|child| reflection::Case::new(Some(self), expected).add_child(child)),
+            (true, Err(_)) => None,
+            (false, Err(err)) => Some(
+                reflection::Case::new(Some(self), false)
+                    .add_product(reflection::Product::new("error", err)),
+            ),
+        }
+    }
 }
 
 /// `Predicate` extension adapting a `slice` Predicate.

--- a/src/path/fc.rs
+++ b/src/path/fc.rs
@@ -11,6 +11,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::path;
 
+use reflection;
 use Predicate;
 
 fn read_file(path: &path::Path) -> io::Result<Vec<u8>> {
@@ -38,6 +39,12 @@ where
         let buffer = read_file(path)?;
         Ok(self.p.eval(&buffer))
     }
+}
+
+impl<P> reflection::PredicateReflection for FileContentPredicate<P>
+where
+    P: Predicate<[u8]>,
+{
 }
 
 impl<P> fmt::Display for FileContentPredicate<P>

--- a/src/path/fc.rs
+++ b/src/path/fc.rs
@@ -45,6 +45,10 @@ impl<P> reflection::PredicateReflection for FileContentPredicate<P>
 where
     P: Predicate<[u8]>,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![reflection::Child::new("predicate", &self.p)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<P> fmt::Display for FileContentPredicate<P>

--- a/src/path/fs.rs
+++ b/src/path/fs.rs
@@ -11,6 +11,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::path;
 
+use core;
 use reflection;
 use Predicate;
 
@@ -59,11 +60,23 @@ impl Predicate<path::Path> for BinaryFilePredicate {
     fn eval(&self, path: &path::Path) -> bool {
         self.eval(path).unwrap_or(false)
     }
+
+    fn find_case<'a>(
+        &'a self,
+        expected: bool,
+        variable: &path::Path,
+    ) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
+    }
 }
 
 impl Predicate<[u8]> for BinaryFilePredicate {
     fn eval(&self, actual: &[u8]) -> bool {
         self.content.debug == actual
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &[u8]) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 
@@ -120,11 +133,23 @@ impl Predicate<path::Path> for StrFilePredicate {
     fn eval(&self, path: &path::Path) -> bool {
         self.eval(path).unwrap_or(false)
     }
+
+    fn find_case<'a>(
+        &'a self,
+        expected: bool,
+        variable: &path::Path,
+    ) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
+    }
 }
 
 impl Predicate<str> for StrFilePredicate {
     fn eval(&self, actual: &str) -> bool {
         self.content == actual
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 

--- a/src/path/fs.rs
+++ b/src/path/fs.rs
@@ -11,6 +11,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::path;
 
+use reflection;
 use Predicate;
 
 fn read_file(path: &path::Path) -> io::Result<Vec<u8>> {
@@ -66,6 +67,8 @@ impl Predicate<[u8]> for BinaryFilePredicate {
     }
 }
 
+impl reflection::PredicateReflection for BinaryFilePredicate {}
+
 impl fmt::Display for BinaryFilePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "var is {}", self.path.display())
@@ -119,6 +122,8 @@ impl Predicate<str> for StrFilePredicate {
         self.content == actual
     }
 }
+
+impl reflection::PredicateReflection for StrFilePredicate {}
 
 impl fmt::Display for StrFilePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/path/ft.rs
+++ b/src/path/ft.rs
@@ -22,8 +22,12 @@ enum FileType {
 }
 
 impl FileType {
-    fn from_path(path: &path::Path) -> io::Result<FileType> {
-        let file_type = path.metadata()?.file_type();
+    fn from_path(path: &path::Path, follow: bool) -> io::Result<FileType> {
+        let file_type = if follow {
+            path.metadata()
+        } else {
+            path.symlink_metadata()
+        }?.file_type();
         if file_type.is_dir() {
             return Ok(FileType::Dir);
         }
@@ -76,7 +80,7 @@ impl FileTypePredicate {
     /// Allow to create an `FileTypePredicate` from a `path`
     pub fn from_path(path: &path::Path) -> io::Result<FileTypePredicate> {
         Ok(FileTypePredicate {
-            ft: FileType::from_path(path)?,
+            ft: FileType::from_path(path, true)?,
             follow: true,
         })
     }
@@ -92,6 +96,32 @@ impl Predicate<path::Path> for FileTypePredicate {
         metadata
             .map(|m| self.ft.eval(m.file_type()))
             .unwrap_or(false)
+    }
+
+    fn find_case<'a>(
+        &'a self,
+        expected: bool,
+        variable: &path::Path,
+    ) -> Option<reflection::Case<'a>> {
+        let actual_type = FileType::from_path(variable, self.follow);
+        match (expected, actual_type) {
+            (_, Ok(actual_type)) => {
+                let result = self.ft == actual_type;
+                if result == expected {
+                    Some(
+                        reflection::Case::new(Some(self), result)
+                            .add_product(reflection::Product::new("actual filetype", actual_type)),
+                    )
+                } else {
+                    None
+                }
+            }
+            (true, Err(_)) => None,
+            (false, Err(err)) => Some(
+                reflection::Case::new(Some(self), false)
+                    .add_product(reflection::Product::new("error", err)),
+            ),
+        }
     }
 }
 

--- a/src/path/ft.rs
+++ b/src/path/ft.rs
@@ -11,6 +11,7 @@ use std::fs;
 use std::io;
 use std::path;
 
+use reflection;
 use Predicate;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -93,6 +94,8 @@ impl Predicate<path::Path> for FileTypePredicate {
             .unwrap_or(false)
     }
 }
+
+impl reflection::PredicateReflection for FileTypePredicate {}
 
 impl fmt::Display for FileTypePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/path/ft.rs
+++ b/src/path/ft.rs
@@ -95,7 +95,12 @@ impl Predicate<path::Path> for FileTypePredicate {
     }
 }
 
-impl reflection::PredicateReflection for FileTypePredicate {}
+impl reflection::PredicateReflection for FileTypePredicate {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("follow", &self.follow)];
+        Box::new(params.into_iter())
+    }
+}
 
 impl fmt::Display for FileTypePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/reflection.rs
+++ b/src/reflection.rs
@@ -95,3 +95,38 @@ impl<'a> fmt::Debug for Child<'a> {
         write!(f, "({:?}, {})", self.0, self.1)
     }
 }
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct DebugAdapter<T>
+where
+    T: fmt::Debug,
+{
+    pub(crate) debug: T,
+}
+
+impl<T> DebugAdapter<T>
+where
+    T: fmt::Debug,
+{
+    pub fn new(debug: T) -> Self {
+        Self { debug }
+    }
+}
+
+impl<T> fmt::Display for DebugAdapter<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:#?}", self.debug)
+    }
+}
+
+impl<T> fmt::Debug for DebugAdapter<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.debug.fmt(f)
+    }
+}

--- a/src/reflection.rs
+++ b/src/reflection.rs
@@ -8,7 +8,9 @@
 
 //! Introspect into the state of a `Predicate`.
 
+use std::borrow;
 use std::fmt;
+use std::slice;
 
 /// Introspect the state of a `Predicate`.
 pub trait PredicateReflection: fmt::Display {
@@ -91,6 +93,166 @@ impl<'a> fmt::Display for Child<'a> {
 }
 
 impl<'a> fmt::Debug for Child<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({:?}, {})", self.0, self.1)
+    }
+}
+
+/// A descriptive explanation for why a predicate failed.
+pub struct Case<'a> {
+    predicate: Option<&'a PredicateReflection>,
+    result: bool,
+    products: Vec<Product>,
+    children: Vec<Case<'a>>,
+}
+
+impl<'a> Case<'a> {
+    /// Create a new `Case` describing the result of a `Predicate`.
+    pub fn new(predicate: Option<&'a PredicateReflection>, result: bool) -> Self {
+        Self {
+            predicate,
+            result,
+            products: Default::default(),
+            children: Default::default(),
+        }
+    }
+
+    /// Add an additional by product to a `Case`.
+    pub fn add_product(mut self, product: Product) -> Self {
+        self.products.push(product);
+        self
+    }
+
+    /// Add an additional by product to a `Case`.
+    pub fn add_child(mut self, child: Case<'a>) -> Self {
+        self.children.push(child);
+        self
+    }
+
+    /// The `Predicate` that produced this case.
+    pub fn predicate(&self) -> Option<&PredicateReflection> {
+        self.predicate
+    }
+
+    /// The result of this case.
+    pub fn result(&self) -> bool {
+        self.result
+    }
+
+    /// Access the by-products from determining this case.
+    pub fn products(&self) -> CaseProducts {
+        CaseProducts {
+            0: self.products.iter(),
+        }
+    }
+
+    /// Access the sub-cases.
+    pub fn children(&self) -> CaseChildren {
+        CaseChildren {
+            0: self.children.iter(),
+        }
+    }
+}
+
+impl<'a> fmt::Debug for Case<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let predicate = if let Some(ref predicate) = self.predicate {
+            format!("Some({})", predicate)
+        } else {
+            "None".to_owned()
+        };
+        f.debug_struct("Case")
+            .field("predicate", &predicate)
+            .field("result", &self.result)
+            .field("products", &self.products)
+            .field("children", &self.children)
+            .finish()
+    }
+}
+
+/// Iterator over a `Case`s by-products.
+#[derive(Debug, Clone)]
+pub struct CaseProducts<'a>(slice::Iter<'a, Product>);
+
+impl<'a> Iterator for CaseProducts<'a> {
+    type Item = &'a Product;
+
+    fn next(&mut self) -> Option<&'a Product> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+}
+
+/// Iterator over a `Case`s sub-cases.
+#[derive(Debug, Clone)]
+pub struct CaseChildren<'a>(slice::Iter<'a, Case<'a>>);
+
+impl<'a> Iterator for CaseChildren<'a> {
+    type Item = &'a Case<'a>;
+
+    fn next(&mut self) -> Option<&'a Case<'a>> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+}
+
+/// A by-product of a predicate evaluation.
+///
+/// ```rust
+/// use predicates;
+///
+/// let product = predicates::reflection::Product::new("key", "value");
+/// println!("{}", product);
+/// let product = predicates::reflection::Product::new(format!("key-{}", 5), 30);
+/// println!("{}", product);
+/// ```
+pub struct Product(borrow::Cow<'static, str>, Box<fmt::Display>);
+
+impl Product {
+    /// Create a new `Product`.
+    pub fn new<S, D>(key: S, value: D) -> Self
+    where
+        S: Into<borrow::Cow<'static, str>>,
+        D: fmt::Display + 'static,
+    {
+        Self {
+            0: key.into(),
+            1: Box::new(value),
+        }
+    }
+
+    /// Access the `Product` name.
+    pub fn name(&self) -> &str {
+        self.0.as_ref()
+    }
+
+    /// Access the `Product` value.
+    pub fn value(&self) -> &fmt::Display {
+        &self.1
+    }
+}
+
+impl<'a> fmt::Display for Product {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}", self.0, self.1)
+    }
+}
+
+impl<'a> fmt::Debug for Product {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({:?}, {})", self.0, self.1)
     }

--- a/src/reflection.rs
+++ b/src/reflection.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2018 The predicates-rs Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Introspect into the state of a `Predicate`.
+
+use std::fmt;
+
+/// Introspect the state of a `Predicate`.
+pub trait PredicateReflection: fmt::Display {
+    /// Parameters of the current `Predicate`.
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = Parameter<'a>> + 'a> {
+        let params = vec![];
+        Box::new(params.into_iter())
+    }
+
+    /// Nested `Predicate`s of the current `Predicate`.
+    fn children<'a>(&'a self) -> Box<Iterator<Item = Child<'a>> + 'a> {
+        let params = vec![];
+        Box::new(params.into_iter())
+    }
+}
+
+/// A view of a `Predicate` parameter, provided by reflection.
+///
+/// ```rust
+/// use predicates;
+///
+/// let param = predicates::reflection::Parameter::new("key", &10);
+/// println!("{}", param);
+/// ```
+pub struct Parameter<'a>(&'a str, &'a fmt::Display);
+
+impl<'a> Parameter<'a> {
+    /// Create a new `Parameter`.
+    pub fn new(key: &'a str, value: &'a fmt::Display) -> Self {
+        Self { 0: key, 1: value }
+    }
+
+    /// Access the `Parameter` name.
+    pub fn name(&self) -> &str {
+        self.0
+    }
+
+    /// Access the `Parameter` value.
+    pub fn value(&self) -> &fmt::Display {
+        self.1
+    }
+}
+
+impl<'a> fmt::Display for Parameter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}", self.0, self.1)
+    }
+}
+
+impl<'a> fmt::Debug for Parameter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({:?}, {})", self.0, self.1)
+    }
+}
+
+/// A view of a `Predicate` child, provided by reflection.
+pub struct Child<'a>(&'a str, &'a PredicateReflection);
+
+impl<'a> Child<'a> {
+    /// Create a new `Predicate` child.
+    pub fn new(key: &'a str, value: &'a PredicateReflection) -> Self {
+        Self { 0: key, 1: value }
+    }
+
+    /// Access the `Child`'s name.
+    pub fn name(&self) -> &str {
+        self.0
+    }
+
+    /// Access the `Child` `Predicate`.
+    pub fn value(&self) -> &PredicateReflection {
+        self.1
+    }
+}
+
+impl<'a> fmt::Display for Child<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}", self.0, self.1)
+    }
+}
+
+impl<'a> fmt::Debug for Child<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({:?}, {})", self.0, self.1)
+    }
+}

--- a/src/str/adapters.rs
+++ b/src/str/adapters.rs
@@ -11,9 +11,9 @@ use std::fmt;
 use std::str;
 
 use reflection;
-use Predicate;
 #[cfg(feature = "normalize-line-endings")]
 use str::normalize::NormalizedPredicate;
+use Predicate;
 
 /// Predicate adaper that trims the variable being tested.
 ///
@@ -32,6 +32,10 @@ where
 {
     fn eval(&self, variable: &str) -> bool {
         self.p.eval(variable.trim())
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
+        self.p.find_case(expected, variable.trim())
     }
 }
 
@@ -72,6 +76,24 @@ where
     fn eval(&self, variable: &ffi::OsStr) -> bool {
         variable.to_str().map(|s| self.p.eval(s)).unwrap_or(false)
     }
+
+    fn find_case<'a>(
+        &'a self,
+        expected: bool,
+        variable: &ffi::OsStr,
+    ) -> Option<reflection::Case<'a>> {
+        let var_str = variable.to_str();
+        match (expected, var_str) {
+            (_, Some(var_str)) => self.p.find_case(expected, var_str).map(|child| {
+                child.add_product(reflection::Product::new("var as str", var_str.to_owned()))
+            }),
+            (true, None) => None,
+            (false, None) => Some(
+                reflection::Case::new(Some(self), false)
+                    .add_product(reflection::Product::new("error", "Invalid UTF-8 string")),
+            ),
+        }
+    }
 }
 
 impl<P> Predicate<[u8]> for Utf8Predicate<P>
@@ -82,6 +104,20 @@ where
         str::from_utf8(variable)
             .map(|s| self.p.eval(s))
             .unwrap_or(false)
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &[u8]) -> Option<reflection::Case<'a>> {
+        let var_str = str::from_utf8(variable);
+        match (expected, var_str) {
+            (_, Ok(var_str)) => self.p.find_case(expected, var_str).map(|child| {
+                child.add_product(reflection::Product::new("var as str", var_str.to_owned()))
+            }),
+            (true, Err(_)) => None,
+            (false, Err(err)) => Some(
+                reflection::Case::new(Some(self), false)
+                    .add_product(reflection::Product::new("error", err)),
+            ),
+        }
     }
 }
 
@@ -150,7 +186,7 @@ where
     ///
     /// ```
     /// use predicates::prelude::*;
-    /// 
+    ///
     /// let predicate_fn = predicate::eq("Hello World!\n").normalize();
     /// assert_eq!(true, predicate_fn.eval("Hello World!\n"));
     /// assert_eq!(true, predicate_fn.eval("Hello World!\r"));
@@ -162,7 +198,6 @@ where
     fn normalize(self) -> NormalizedPredicate<Self> {
         NormalizedPredicate { p: self }
     }
-
 }
 
 impl<P> PredicateStrExt for P

--- a/src/str/adapters.rs
+++ b/src/str/adapters.rs
@@ -39,6 +39,10 @@ impl<P> reflection::PredicateReflection for TrimPredicate<P>
 where
     P: Predicate<str>,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![reflection::Child::new("predicate", &self.p)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<P> fmt::Display for TrimPredicate<P>
@@ -85,6 +89,10 @@ impl<P> reflection::PredicateReflection for Utf8Predicate<P>
 where
     P: Predicate<str>,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![reflection::Child::new("predicate", &self.p)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<P> fmt::Display for Utf8Predicate<P>

--- a/src/str/adapters.rs
+++ b/src/str/adapters.rs
@@ -10,6 +10,7 @@ use std::ffi;
 use std::fmt;
 use std::str;
 
+use reflection;
 use Predicate;
 #[cfg(feature = "normalize-line-endings")]
 use str::normalize::NormalizedPredicate;
@@ -32,6 +33,12 @@ where
     fn eval(&self, variable: &str) -> bool {
         self.p.eval(variable.trim())
     }
+}
+
+impl<P> reflection::PredicateReflection for TrimPredicate<P>
+where
+    P: Predicate<str>,
+{
 }
 
 impl<P> fmt::Display for TrimPredicate<P>
@@ -72,6 +79,12 @@ where
             .map(|s| self.p.eval(s))
             .unwrap_or(false)
     }
+}
+
+impl<P> reflection::PredicateReflection for Utf8Predicate<P>
+where
+    P: Predicate<str>,
+{
 }
 
 impl<P> fmt::Display for Utf8Predicate<P>

--- a/src/str/basics.rs
+++ b/src/str/basics.rs
@@ -185,6 +185,19 @@ impl Predicate<str> for MatchesPredicate {
     fn eval(&self, variable: &str) -> bool {
         variable.matches(&self.pattern).count() == self.count
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
+        let actual_count = variable.matches(&self.pattern).count();
+        let result = self.count == actual_count;
+        if result == expected {
+            Some(
+                reflection::Case::new(Some(self), result)
+                    .add_product(reflection::Product::new("actual count", actual_count)),
+            )
+        } else {
+            None
+        }
+    }
 }
 
 impl reflection::PredicateReflection for MatchesPredicate {

--- a/src/str/basics.rs
+++ b/src/str/basics.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+use core;
 use reflection;
 use Predicate;
 
@@ -20,6 +21,10 @@ pub struct IsEmptyPredicate {}
 impl Predicate<str> for IsEmptyPredicate {
     fn eval(&self, variable: &str) -> bool {
         variable.is_empty()
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 
@@ -57,6 +62,10 @@ pub struct StartsWithPredicate {
 impl Predicate<str> for StartsWithPredicate {
     fn eval(&self, variable: &str) -> bool {
         variable.starts_with(&self.pattern)
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 
@@ -99,6 +108,10 @@ pub struct EndsWithPredicate {
 impl Predicate<str> for EndsWithPredicate {
     fn eval(&self, variable: &str) -> bool {
         variable.ends_with(&self.pattern)
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 
@@ -161,6 +174,10 @@ impl ContainsPredicate {
 impl Predicate<str> for ContainsPredicate {
     fn eval(&self, variable: &str) -> bool {
         variable.contains(&self.pattern)
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 

--- a/src/str/basics.rs
+++ b/src/str/basics.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+use reflection;
 use Predicate;
 
 /// Predicate that checks for empty strings.
@@ -21,6 +22,8 @@ impl Predicate<str> for IsEmptyPredicate {
         variable.is_empty()
     }
 }
+
+impl reflection::PredicateReflection for IsEmptyPredicate {}
 
 impl fmt::Display for IsEmptyPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -56,6 +59,8 @@ impl Predicate<str> for StartsWithPredicate {
         variable.starts_with(&self.pattern)
     }
 }
+
+impl reflection::PredicateReflection for StartsWithPredicate {}
 
 impl fmt::Display for StartsWithPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -96,6 +101,8 @@ impl Predicate<str> for EndsWithPredicate {
         variable.ends_with(&self.pattern)
     }
 }
+
+impl reflection::PredicateReflection for EndsWithPredicate {}
 
 impl fmt::Display for EndsWithPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -157,6 +164,8 @@ impl Predicate<str> for ContainsPredicate {
     }
 }
 
+impl reflection::PredicateReflection for ContainsPredicate {}
+
 impl fmt::Display for ContainsPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "var.contains({:?})", self.pattern)
@@ -177,6 +186,8 @@ impl Predicate<str> for MatchesPredicate {
         variable.matches(&self.pattern).count() == self.count
     }
 }
+
+impl reflection::PredicateReflection for MatchesPredicate {}
 
 impl fmt::Display for MatchesPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/str/basics.rs
+++ b/src/str/basics.rs
@@ -187,11 +187,16 @@ impl Predicate<str> for MatchesPredicate {
     }
 }
 
-impl reflection::PredicateReflection for MatchesPredicate {}
+impl reflection::PredicateReflection for MatchesPredicate {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("count", &self.count)];
+        Box::new(params.into_iter())
+    }
+}
 
 impl fmt::Display for MatchesPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "var.contains({:?}, {})", self.pattern, self.count)
+        write!(f, "var.contains({})", self.pattern)
     }
 }
 

--- a/src/str/difference.rs
+++ b/src/str/difference.rs
@@ -91,6 +91,20 @@ impl Predicate<str> for DifferencePredicate {
         let change = difference::Changeset::new(&self.orig, edit, &self.split);
         self.op.eval(self.distance, change.distance)
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
+        let change = difference::Changeset::new(&self.orig, variable, &self.split);
+        let result = self.op.eval(self.distance, change.distance);
+        if result == expected {
+            Some(
+                reflection::Case::new(Some(self), result)
+                    .add_product(reflection::Product::new("actual distance", change.distance))
+                    .add_product(reflection::Product::new("diff", change)),
+            )
+        } else {
+            None
+        }
+    }
 }
 
 impl reflection::PredicateReflection for DifferencePredicate {

--- a/src/str/difference.rs
+++ b/src/str/difference.rs
@@ -11,6 +11,7 @@ use std::fmt;
 
 use difference;
 
+use reflection;
 use Predicate;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -91,6 +92,8 @@ impl Predicate<str> for DifferencePredicate {
         self.op.eval(self.distance, change.distance)
     }
 }
+
+impl reflection::PredicateReflection for DifferencePredicate {}
 
 impl fmt::Display for DifferencePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/str/difference.rs
+++ b/src/str/difference.rs
@@ -93,13 +93,18 @@ impl Predicate<str> for DifferencePredicate {
     }
 }
 
-impl reflection::PredicateReflection for DifferencePredicate {}
+impl reflection::PredicateReflection for DifferencePredicate {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("original", &self.orig)];
+        Box::new(params.into_iter())
+    }
+}
 
 impl fmt::Display for DifferencePredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.op {
-            DistanceOp::Similar => write!(f, "var - {:?} <= {}", self.orig, self.distance),
-            DistanceOp::Different => write!(f, "{} < var - {:?}", self.distance, self.orig),
+            DistanceOp::Similar => write!(f, "var - original <= {}", self.distance),
+            DistanceOp::Different => write!(f, "{} < var - original", self.distance),
         }
     }
 }

--- a/src/str/normalize.rs
+++ b/src/str/normalize.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use reflection;
 use std::fmt;
 use Predicate;
 
@@ -23,12 +24,19 @@ where
     pub(crate) p: P,
 }
 
+impl<P> reflection::PredicateReflection for NormalizedPredicate<P>
+where
+    P: Predicate<str>,
+{
+}
+
 impl<P> Predicate<str> for NormalizedPredicate<P>
 where
     P: Predicate<str>,
 {
     fn eval(&self, variable: &str) -> bool {
-        self.p.eval(&String::from_iter(normalized(variable.chars())))
+        self.p
+            .eval(&String::from_iter(normalized(variable.chars())))
     }
 }
 

--- a/src/str/normalize.rs
+++ b/src/str/normalize.rs
@@ -42,6 +42,11 @@ where
         self.p
             .eval(&String::from_iter(normalized(variable.chars())))
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
+        let variable = String::from_iter(normalized(variable.chars()));
+        self.p.find_case(expected, &variable)
+    }
 }
 
 impl<P> fmt::Display for NormalizedPredicate<P>

--- a/src/str/normalize.rs
+++ b/src/str/normalize.rs
@@ -28,6 +28,10 @@ impl<P> reflection::PredicateReflection for NormalizedPredicate<P>
 where
     P: Predicate<str>,
 {
+    fn children<'a>(&'a self) -> Box<Iterator<Item = reflection::Child<'a>> + 'a> {
+        let params = vec![reflection::Child::new("predicate", &self.p)];
+        Box::new(params.into_iter())
+    }
 }
 
 impl<P> Predicate<str> for NormalizedPredicate<P>

--- a/src/str/regex.rs
+++ b/src/str/regex.rs
@@ -68,6 +68,19 @@ impl Predicate<str> for RegexMatchesPredicate {
     fn eval(&self, variable: &str) -> bool {
         self.re.find_iter(variable).count() == self.count
     }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
+        let actual_count = self.re.find_iter(variable).count();
+        let result = self.count == actual_count;
+        if result == expected {
+            Some(
+                reflection::Case::new(Some(self), result)
+                    .add_product(reflection::Product::new("actual count", actual_count)),
+            )
+        } else {
+            None
+        }
+    }
 }
 
 impl reflection::PredicateReflection for RegexMatchesPredicate {

--- a/src/str/regex.rs
+++ b/src/str/regex.rs
@@ -10,6 +10,7 @@ use std::fmt;
 
 use regex;
 
+use core;
 use reflection;
 use Predicate;
 
@@ -44,6 +45,10 @@ impl RegexPredicate {
 impl Predicate<str> for RegexPredicate {
     fn eval(&self, variable: &str) -> bool {
         self.re.is_match(variable)
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
+        core::default_find_case(self, expected, variable)
     }
 }
 

--- a/src/str/regex.rs
+++ b/src/str/regex.rs
@@ -10,6 +10,7 @@ use std::fmt;
 
 use regex;
 
+use reflection;
 use Predicate;
 
 /// An error that occurred during parsing or compiling a regular expression.
@@ -46,6 +47,8 @@ impl Predicate<str> for RegexPredicate {
     }
 }
 
+impl reflection::PredicateReflection for RegexPredicate {}
+
 impl fmt::Display for RegexPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "var.is_match({})", self.re)
@@ -66,6 +69,8 @@ impl Predicate<str> for RegexMatchesPredicate {
         self.re.find_iter(variable).count() == self.count
     }
 }
+
+impl reflection::PredicateReflection for RegexMatchesPredicate {}
 
 impl fmt::Display for RegexMatchesPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/str/regex.rs
+++ b/src/str/regex.rs
@@ -70,11 +70,16 @@ impl Predicate<str> for RegexMatchesPredicate {
     }
 }
 
-impl reflection::PredicateReflection for RegexMatchesPredicate {}
+impl reflection::PredicateReflection for RegexMatchesPredicate {
+    fn parameters<'a>(&'a self) -> Box<Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("count", &self.count)];
+        Box::new(params.into_iter())
+    }
+}
 
 impl fmt::Display for RegexMatchesPredicate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "var.is_match({}).count({})", self.re, self.count)
+        write!(f, "var.is_match({})", self.re)
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,0 +1,60 @@
+// Copyright (c) 2018 The predicates-rs Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Render `Case` as a tree.
+
+use std::fmt;
+
+use treeline;
+
+use reflection;
+
+/// Render `Self` as a displayable tree.
+pub trait CaseTreeExt {
+    /// Render `Self` as a displayable tree.
+    fn tree(&self) -> CaseTree;
+}
+
+impl<'a> CaseTreeExt for reflection::Case<'a> {
+    fn tree(&self) -> CaseTree {
+        CaseTree(convert(self))
+    }
+}
+
+type CaseTreeInner = treeline::Tree<Box<fmt::Display>>;
+
+fn convert<'a>(case: &reflection::Case<'a>) -> CaseTreeInner {
+    let mut leaves: Vec<CaseTreeInner> = vec![];
+
+    leaves.extend(case.predicate().iter().flat_map(|pred| {
+        pred.parameters().map(|item| {
+            let root: Box<fmt::Display> = Box::new(item.to_string());
+            treeline::Tree::new(root, vec![])
+        })
+    }));
+
+    leaves.extend(case.products().map(|item| {
+        let root: Box<fmt::Display> = Box::new(item.to_string());
+        treeline::Tree::new(root, vec![])
+    }));
+
+    leaves.extend(case.children().map(|item| convert(item)));
+
+    let root = Box::new(case.predicate().map(|p| p.to_string()).unwrap_or_default());
+    CaseTreeInner::new(root, leaves)
+}
+
+/// A `Case` rendered as a tree for display.
+#[allow(missing_debug_implementations)]
+pub struct CaseTree(CaseTreeInner);
+
+impl fmt::Display for CaseTree {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}


### PR DESCRIPTION
Output of `case_tree` example:
```
var is 5
((! var != 5) && var >= 5)
├── (! var != 5)
|   └── var != 5
└── var >= 5
```

An extension trait is added to make a `Display`able struct that will print out the above tree.
- This is built off of `find_case` which will find the `Case` that prove whether the `Predicate` succeeds or fails.
- To reduce overhead, `Case` only owns by-`Product`s of the `Predicate` evaluation, `parameters` are made available as references on the `PredicateReflection` trait
  - This had the benefit of simplifying the `Case` API because `Parameter` and `Product` have different ownership requirements.
- `PredicateReflection` is also use to homogenize the predicate tree
  - Because of predicate adapters, you could have a tree that includes `Predicate<[u8]>`, `Predicate<str>`, etc.

Once this is in, to reduce API breaks from impacting the assert-ecosystem, #30 will be implemented and this repo will be turned into a workspace for
- `predicate-core`: `core.rs`, `reflection.rs`
- `predicate-tree`: `tree.rs`
- `predicates`
  - All existing predicates
  - Re-export `predicate-core`

aka the only change to most end-users will be `predicate-tree` being removed from the API while the assert-ecosystem will use `predicate_core::Predicate` in its public API.

This supersedes #39 due to having an API that we are more comfortable moving to 1.0
- Unlike #39, we do not include `item` in the `Display`, allowing us to avoid requiring `Item: Debug`.   Instead we just rely on every `Predicate` implementing `Display`, usually doing so by having an `Item: Debug` requirement but clients are free to bypass that by creating their own `Predicate`.

BREAKING CHANGES
- Predicates must also implement `PredicateReflection`.  Provided methods make this a `impl PredicateReflection for X {}`