### PR TITLE
Use T: ?Sized everywhere for FnPredicate so slices and str work

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -19,6 +19,7 @@ use Predicate;
 pub struct FnPredicate<F, T>
 where
     F: Fn(&T) -> bool,
+    T: ?Sized,
 {
     function: F,
     name: &'static str,
@@ -28,6 +29,7 @@ where
 impl<F, T> FnPredicate<F, T>
 where
     F: Fn(&T) -> bool,
+    T: ?Sized,
 {
     /// Provide a descriptive name for this function.
     ///
@@ -54,6 +56,7 @@ where
 impl<F, T> Predicate<T> for FnPredicate<F, T>
 where
     F: Fn(&T) -> bool,
+    T: ?Sized,
 {
     fn eval(&self, variable: &T) -> bool {
         (self.function)(variable)
@@ -63,6 +66,7 @@ where
 impl<F, T> fmt::Display for FnPredicate<F, T>
 where
     F: Fn(&T) -> bool,
+    T: ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}(var)", self.name)
@@ -94,10 +98,18 @@ where
 pub fn function<F, T>(function: F) -> FnPredicate<F, T>
 where
     F: Fn(&T) -> bool,
+    T: ?Sized,
 {
     FnPredicate {
         function,
         name: "fn",
         _phantom: PhantomData,
     }
+}
+
+#[test]
+fn str_function() {
+    let f = function(|x: &str| x == "hello");
+    assert!(f.eval(&"hello"));
+    assert!(!f.eval(&"goodbye"));
 }


### PR DESCRIPTION
The implicit `T: Sized` bound on `FnPredicate` meant that function
predicates could not be used with slices or `str`. Removing that bound
by adding `T: ?Sized` to all the declarations makes this work.

I ran into this while trying to use a function predicate with assert_cmd's
[`Assert::stdout`](https://docs.rs/assert_cmd/0.6.0/assert_cmd/assert/struct.Assert.html#method.stdout)
method, which expects a `Predicate<[u8]>`. Without this patch it's not
possible to construct a `FnPredicate` that satisfies that.