### PR TITLE
fix: make Predicate::eval for isClosePredicate work with latest float…

### DIFF
--- a/src/float/close.rs
+++ b/src/float/close.rs
@@ -9,6 +9,7 @@
 use std::fmt;
 
 use float_cmp::ApproxEq;
+use float_cmp::F64Margin;
 use float_cmp::Ulps;
 
 use reflection;
@@ -83,7 +84,10 @@ impl IsClosePredicate {
 
 impl Predicate<f64> for IsClosePredicate {
     fn eval(&self, variable: &f64) -> bool {
-        variable.approx_eq(&self.target, self.epsilon, self.ulps)
+        variable.approx_eq(self.target, F64Margin {
+          epsilon: self.epsilon as f64,
+          ulps: self.ulps as i64
+        })
     }
 
     fn find_case<'a>(&'a self, expected: bool, variable: &f64) -> Option<reflection::Case<'a>> {


### PR DESCRIPTION
…-cmp

The `float-cmp` crate has introduced a breaking change in its `approx_eq()` API
in https://github.com/mikedilger/float-cmp/commit/d93fe51aa928cfdb269af67331846d533e850ec4 which was released as
a feature release with version `0.4.1` in https://github.com/mikedilger/float-cmp/commit/edb0717fefe8e5896d239e4354f7bfaaac91133f

Since it's a minor version bump, it gets included in predicate-rs' dependency range,
breaking many people's code.

This commit adjust predicate-rs' source to comply with the latest API changes.

Closes #78 and https://github.com/mikedilger/float-cmp/issues/17

<!--
Quick reminders:
- Was CHANGELOG.md updated?
- Were tests written?
- Is commit history clean?
- Were copyright statements updated?
- Was the predicate guide updated?
-->
