### PR TITLE
Include NamePredicate in find_case results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+### Fixed
+- `NamePredicate` now adds itself to the `Case` returned by `find_case`.
+
 ## [1.0.5] - 2020-07-18
 
 ### Fixed

--- a/src/name.rs
+++ b/src/name.rs
@@ -38,7 +38,9 @@ where
     }
 
     fn find_case<'a>(&'a self, expected: bool, variable: &Item) -> Option<reflection::Case<'a>> {
-        self.inner.find_case(expected, variable)
+        self.inner
+            .find_case(expected, variable)
+            .map(|child_case| reflection::Case::new(Some(self), expected).add_child(child_case))
     }
 }
 


### PR DESCRIPTION
The `NamePredicate` is quite handy for improving the readability of
failed assertions (in my case, when using the `mockall` crate). This PR
adds the specified name to the output of `find_case`, which `NamePredicate`
previously forwarded transparently to the child predicate.