### PR TITLE
WIP: Change diff crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ azure-devops = { project = "assert-rs", pipeline = "predicates-rs" }
 predicates-core = { version = "1.0", path = "crates/core" }
 difference = { version = "2.0", optional = true }
 dissimilar = { version = "1.0.2", optional = true }
+similar = { version = "1.3.0", optional = true }
 normalize-line-endings = { version = "0.3.0", optional = true }
 regex = { version="1.0", optional = true }
 float-cmp = { version="0.8", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ azure-devops = { project = "assert-rs", pipeline = "predicates-rs" }
 [dependencies]
 predicates-core = { version = "1.0", path = "crates/core" }
 difference = { version = "2.0", optional = true }
+dissimilar = { version = "1.0.2", optional = true }
 normalize-line-endings = { version = "0.3.0", optional = true }
 regex = { version="1.0", optional = true }
 float-cmp = { version="0.8", optional = true }

--- a/crates/core/src/reflection.rs
+++ b/crates/core/src/reflection.rs
@@ -146,6 +146,14 @@ impl<'a> Case<'a> {
         }
     }
 
+    /// Get the Stringified value of the first by-product with that name.
+    pub fn product_value(&self, name: &str) -> Option<String> {
+        self.products
+            .iter()
+            .find(|p| p.name() == name)
+            .map(|p| format!("{}", p.value()))
+    }
+
     /// Access the sub-cases.
     pub fn children(&self) -> CaseChildren<'_> {
         CaseChildren {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -36,6 +36,9 @@ pub mod predicate {
         #[cfg(feature = "dissimilar")]
         pub use crate::str::{diff2, similar2};
 
+        #[cfg(feature = "similar")]
+        pub use crate::str::{diff3, similar3};
+
         #[cfg(feature = "regex")]
         pub use crate::str::is_match;
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -33,6 +33,9 @@ pub mod predicate {
         #[cfg(feature = "difference")]
         pub use crate::str::{diff, similar};
 
+        #[cfg(feature = "dissimilar")]
+        pub use crate::str::{diff2, similar2};
+
         #[cfg(feature = "regex")]
         pub use crate::str::is_match;
     }

--- a/src/str/dissimilar.rs
+++ b/src/str/dissimilar.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The predicates-rs Project Developers.
+// Copyright (c) 2021 The predicates-rs Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/str/dissimilar.rs
+++ b/src/str/dissimilar.rs
@@ -1,0 +1,188 @@
+// Copyright (c) 2018 The predicates-rs Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::borrow;
+use std::fmt;
+
+use crate::reflection;
+use crate::Predicate;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DistanceOp {
+    Similar,
+    Different,
+}
+
+impl DistanceOp {
+    fn eval(self, limit: i32, distance: i32) -> bool {
+        match self {
+            DistanceOp::Similar => distance <= limit,
+            DistanceOp::Different => limit < distance,
+        }
+    }
+}
+
+/// Predicate that diffs two strings.
+///
+/// This is created by the `predicate::str::similar`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DissimilarPredicate {
+    orig: borrow::Cow<'static, str>,
+    distance: i32,
+    op: DistanceOp,
+}
+
+impl DissimilarPredicate {
+    /// The maximum allowed edit distance.
+    ///
+    /// Default: `0`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use predicates::prelude::*;
+    ///
+    /// let predicate_fn = predicate::str::similar2("Hello World!").distance(1);
+    /// assert_eq!(true, predicate_fn.eval("Hello World!"));
+    /// assert_eq!(true, predicate_fn.eval("Hello World"));
+    /// assert_eq!(false, predicate_fn.eval("Hello World?"));
+    /// ```
+    pub fn distance(mut self, distance: i32) -> Self {
+        self.distance = distance;
+        self
+    }
+}
+
+fn distance(chunks: &Vec<dissimilar::Chunk>) -> i32 {
+    use dissimilar::Chunk::*;
+    chunks.iter().fold(0, |n, c| match c {
+        Equal(_) => n,
+        _ => n + 1,
+    })
+}
+
+impl Predicate<str> for DissimilarPredicate {
+    fn eval(&self, edit: &str) -> bool {
+        let chunks = dissimilar::diff(&self.orig, edit);
+        self.op.eval(self.distance, distance(&chunks))
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
+        let chunks = dissimilar::diff(&self.orig, variable);
+        let distance = distance(&chunks);
+        let result = self.op.eval(self.distance, distance);
+        if result == expected {
+            Some(
+                reflection::Case::new(Some(self), result)
+                    .add_product(reflection::Product::new("distance", distance))
+                    .add_product(reflection::Product::new(
+                        "chunks",
+                        DissimilarChanges::from(&chunks),
+                    )),
+            )
+        } else {
+            None
+        }
+    }
+}
+
+enum DissimilarOwnedChunk {
+    Equal(String),
+    Delete(String),
+    Insert(String),
+}
+struct DissimilarChanges {
+    chunks: Vec<DissimilarOwnedChunk>,
+}
+impl From<&Vec<dissimilar::Chunk<'_>>> for DissimilarChanges {
+    fn from(v: &Vec<dissimilar::Chunk<'_>>) -> Self {
+        let chunks = v
+            .iter()
+            .map(|c| match c {
+                dissimilar::Chunk::Equal(s) => DissimilarOwnedChunk::Equal(s.to_string()),
+                dissimilar::Chunk::Delete(s) => DissimilarOwnedChunk::Delete(s.to_string()),
+                dissimilar::Chunk::Insert(s) => DissimilarOwnedChunk::Insert(s.to_string()),
+            })
+            .collect();
+        Self { chunks }
+    }
+}
+
+impl fmt::Display for DissimilarChanges {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use DissimilarOwnedChunk::*;
+        for d in &self.chunks {
+            match *d {
+                Equal(ref x) => write!(f, "{}", x)?,
+                Delete(ref x) => write!(f, "\x1b[92m{}\x1b[0m", x)?,
+                Insert(ref x) => write!(f, "\x1b[91m{}\x1b[0m", x)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+impl reflection::PredicateReflection for DissimilarPredicate {
+    fn parameters<'a>(&'a self) -> Box<dyn Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("original", &self.orig)];
+        Box::new(params.into_iter())
+    }
+}
+
+impl fmt::Display for DissimilarPredicate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.op {
+            DistanceOp::Similar => write!(f, "var - original <= {}", self.distance),
+            DistanceOp::Different => write!(f, "{} < var - original", self.distance),
+        }
+    }
+}
+
+/// Creates a new `Predicate` that diffs two strings.
+///
+/// # Examples
+///
+/// ```
+/// use predicates::prelude::*;
+///
+/// let predicate_fn = predicate::str::diff("Hello World");
+/// assert_eq!(false, predicate_fn.eval("Hello World"));
+/// assert_eq!(true, predicate_fn.eval("Goodbye World"));
+/// ```
+pub fn diff2<S>(orig: S) -> DissimilarPredicate
+where
+    S: Into<borrow::Cow<'static, str>>,
+{
+    DissimilarPredicate {
+        orig: orig.into(),
+        distance: 0,
+        op: DistanceOp::Different,
+    }
+}
+
+/// Creates a new `Predicate` that checks strings for how similar they are.
+///
+/// # Examples
+///
+/// ```
+/// use predicates::prelude::*;
+///
+/// let predicate_fn = predicate::str::similar("Hello World");
+/// assert_eq!(true, predicate_fn.eval("Hello World"));
+/// assert_eq!(false, predicate_fn.eval("Goodbye World"));
+/// ```
+pub fn similar2<S>(orig: S) -> DissimilarPredicate
+where
+    S: Into<borrow::Cow<'static, str>>,
+{
+    DissimilarPredicate {
+        orig: orig.into(),
+        distance: 0,
+        op: DistanceOp::Similar,
+    }
+}

--- a/src/str/dissimilar.rs
+++ b/src/str/dissimilar.rs
@@ -125,7 +125,7 @@ impl fmt::Display for DissimilarPredicate {
 /// ```
 /// use predicates::prelude::*;
 ///
-/// let predicate_fn = predicate::str::diff("Hello World");
+/// let predicate_fn = predicate::str::diff2("Hello World");
 /// assert_eq!(false, predicate_fn.eval("Hello World"));
 /// assert_eq!(true, predicate_fn.eval("Goodbye World"));
 /// ```
@@ -147,7 +147,7 @@ where
 /// ```
 /// use predicates::prelude::*;
 ///
-/// let predicate_fn = predicate::str::similar("Hello World");
+/// let predicate_fn = predicate::str::similar2("Hello World");
 /// assert_eq!(true, predicate_fn.eval("Hello World"));
 /// assert_eq!(false, predicate_fn.eval("Goodbye World"));
 /// ```

--- a/src/str/dissimilar.rs
+++ b/src/str/dissimilar.rs
@@ -29,7 +29,7 @@ impl DistanceOp {
 
 /// Predicate that diffs two strings.
 ///
-/// This is created by the `predicate::str::similar`.
+/// This is created by [predicate::str::similar2] or [predicate::str::diff2].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DissimilarPredicate {
     orig: borrow::Cow<'static, str>,
@@ -38,6 +38,19 @@ pub struct DissimilarPredicate {
 }
 
 impl DissimilarPredicate {
+    /// The split used when identifying changes.
+    ///
+    /// # Deprecated
+    ///
+    /// No longer has any effect. The diff algorithm should find the best split automatically.
+    #[deprecated(since="1.1.0" note="No longer needed, diff algorithm should find the best split")]
+    pub fn split<S>(mut self, split: S) -> Self
+    where
+        S: Into<borrow::Cow<'static, str>>,
+    {
+        self
+    }
+
     /// The maximum allowed edit distance.
     ///
     /// Default: `0`

--- a/src/str/mod.rs
+++ b/src/str/mod.rs
@@ -19,6 +19,12 @@ pub use self::adapters::*;
 mod difference;
 #[cfg(feature = "difference")]
 pub use self::difference::{diff, similar, DifferencePredicate};
+
+#[cfg(feature = "dissimilar")]
+mod dissimilar;
+#[cfg(feature = "dissimilar")]
+pub use self::dissimilar::{diff2, similar2, DissimilarPredicate};
+
 #[cfg(feature = "normalize-line-endings")]
 mod normalize;
 #[cfg(feature = "normalize-line-endings")]

--- a/src/str/mod.rs
+++ b/src/str/mod.rs
@@ -25,6 +25,11 @@ mod dissimilar;
 #[cfg(feature = "dissimilar")]
 pub use self::dissimilar::{diff2, similar2, DissimilarPredicate};
 
+#[cfg(feature = "similar")]
+mod similar;
+#[cfg(feature = "similar")]
+pub use self::similar::{diff3, similar3, SimilarPredicate};
+
 #[cfg(feature = "normalize-line-endings")]
 mod normalize;
 #[cfg(feature = "normalize-line-endings")]

--- a/src/str/similar.rs
+++ b/src/str/similar.rs
@@ -13,33 +13,50 @@ use crate::reflection;
 use crate::Predicate;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum DistanceOp {
+enum SimilarOp {
     Similar,
     Different,
 }
 
-impl DistanceOp {
-    fn eval(self, limit: i32, distance: i32) -> bool {
+impl SimilarOp {
+    fn eval(self, similar: bool) -> bool {
         match self {
-            DistanceOp::Similar => distance <= limit,
-            DistanceOp::Different => limit < distance,
+            SimilarOp::Similar => similar,
+            SimilarOp::Different => !similar,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum SimilarLimit {
+    Ratio(f32),
+    Changes(u32),
+    // TODO: DiffOps(u32,u32,u32) variant that counts insert/delete/replace separately
+    //       It would also be nice to have the option to not generate DiffOp::Replace
+}
+
+impl fmt::Display for SimilarLimit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SimilarLimit::Ratio(r) => write!(f, "ratio({})", r),
+            SimilarLimit::Changes(d) => write!(f, "changes({})", d),
         }
     }
 }
 
 /// Predicate that diffs two strings.
 ///
-/// This is created by the `predicate::str::similar`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// This is created by [`similar3()`](crate::str::similar3) or [`diff3()`](crate::str::diff3).
+#[derive(Debug, Clone, PartialEq)]
 pub struct SimilarPredicate {
     old: borrow::Cow<'static, str>,
     algorithm: similar::Algorithm,
-    distance: i32,
-    op: DistanceOp,
+    op: SimilarOp,
+    limit: SimilarLimit,
 }
 
 impl SimilarPredicate {
-    /// The maximum allowed edit distance.
+    /// The maximum allowed number of changes.
     ///
     /// Default: `0`
     ///
@@ -47,25 +64,102 @@ impl SimilarPredicate {
     ///
     /// ```
     /// use predicates::prelude::*;
+    /// use predicates::str::similar3;
     ///
-    /// let predicate_fn = predicate::str::similar3("Hello World!").distance(1);
-    /// assert_eq!(true, predicate_fn.eval("Hello World!"));
-    /// assert_eq!(true, predicate_fn.eval("Hello World"));
+    /// let s1 = "Hello World!";
+    /// let s2 = "Hello... World?";
     ///
-    /// assert_eq!(false, predicate_fn.eval("Hello... World?"));
-    /// let dist = predicate_fn.find_case(false, "Hello... World?").unwrap().product_value("distance").unwrap();
-    /// assert_eq!("2", &dist);
+    /// assert_eq!(false, similar3(s1).eval(s2));
+    /// assert_eq!(true, similar3(s1).changes(2).eval(s2));
+    /// assert_eq!("changes(2)", &similar3(s1).changes(2).find_case(true, s2).unwrap().product_value("measure").unwrap());
     /// ```
-    pub fn distance(mut self, distance: i32) -> Self {
-        self.distance = distance;
+    pub fn changes(mut self, changes: u32) -> Self {
+        self.limit = SimilarLimit::Changes(changes);
         self
     }
 
-    fn new(old: borrow::Cow<'static, str>, op: DistanceOp) -> Self {
-        Self{old, algorithm: similar::Algorithm::Myers, distance: 0, op}
+    /// The minimum required [similarity](similar::get_diff_ratio).
+    ///
+    /// Default: `1.0`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use predicates::prelude::*;
+    /// use predicates::str::similar3;
+    ///
+    /// let s1 = "Hello World!";
+    /// let s2 = "Hello... World?";
+    ///
+    /// assert_eq!(false, similar3(s1).eval(s2));
+    /// assert_eq!(true, similar3(s1).ratio(0.8).eval(s2));
+    /// assert_eq!("ratio(0.8148148)", &similar3(s1).find_case(false, s2).unwrap().product_value("measure").unwrap());
+    /// ```
+    pub fn ratio(mut self, ratio: f32) -> Self {
+        // FIXME: clamp to 0..1 ? Panic ?
+        self.limit = SimilarLimit::Ratio(ratio);
+        self
     }
 
-    fn diff(&self, chunks: &Vec<similar::DiffOp>) -> String {
+    /// The [diffing algorithm](similar::Algorithm).
+    ///
+    /// Default: [`Myers`](similar::Algorithm::Myers)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use predicates::prelude::*;
+    /// use predicates::str::similar3;
+    /// use similar::Algorithm::*;
+    ///
+    /// let s1 = "Hello World!";
+    /// let s2 = "Hello... World?";
+    /// for (pred, expect) in vec![(similar3(s1), "ratio(0.8148148)"),
+    ///                            (similar3(s1).algorithm(Myers), "ratio(0.8148148)"),
+    ///                            (similar3(s1).algorithm(Lcs), "ratio(0.44444445)"),
+    ///                            (similar3(s1).algorithm(Patience), "ratio(0.8148148)")] {
+    ///   let m = pred.find_case(false, s2).unwrap().product_value("measure").unwrap();
+    ///   assert_eq!(expect, &m);
+    /// }
+    /// ```
+    pub fn algorithm(mut self, alg: similar::Algorithm) -> Self {
+        self.algorithm = alg;
+        self
+    }
+
+    fn new(old: borrow::Cow<'static, str>, op: SimilarOp) -> Self {
+        Self {
+            old,
+            algorithm: similar::Algorithm::Myers,
+            op,
+            limit: SimilarLimit::Ratio(1.0),
+        }
+    }
+
+    fn run(&self, new: &str) -> (bool, Vec<similar::DiffOp>, SimilarLimit) {
+        use similar::DiffOp::*;
+        use SimilarLimit::*;
+
+        let chunks =
+            similar::capture_diff_slices(self.algorithm, self.old.as_bytes(), new.as_bytes());
+        match self.limit {
+            Ratio(r) => {
+                let ratio = similar::get_diff_ratio(&chunks, self.old.len(), new.len());
+                (self.op.eval(ratio >= r), chunks, Ratio(ratio))
+            }
+            Changes(d) => {
+                let changes = chunks.iter().fold(0, |n, c| match c {
+                    Equal { .. } => n,
+                    _ => n + 1,
+                });
+                (self.op.eval(changes <= d), chunks, Changes(changes))
+            }
+        }
+    }
+
+    /// Output a formated diff
+    fn diff(&self, old: &str, new: &str, chunks: &[similar::DiffOp]) -> String {
+        use similar::DiffOp::*;
         use std::fmt::Write;
 
         let mut f = String::with_capacity(chunks.len());
@@ -88,30 +182,17 @@ impl SimilarPredicate {
     }
 }
 
-// TODO `similar offers a diff_ratio which might be better
-// TODO s/distance/changes/ ? Reserve "distance" for some levenstein-like metric ?
-fn distance(chunks: &Vec<similar::DiffOp>) -> i32 {
-    use similar::DiffOp::*;
-    chunks.iter().fold(0, |n, c| match c {
-        Equal{..} => n,
-        _ => n + 1,
-    })
-}
-
 impl Predicate<str> for SimilarPredicate {
     fn eval(&self, new: &str) -> bool {
-        let chunks = similar::capture_diff_slices(self.algorithm, self.old.as_bytes(), new.as_bytes());
-        self.op.eval(self.distance, distance(&chunks))
+        self.run(new).0
     }
 
     fn find_case<'a>(&'a self, expected: bool, new: &str) -> Option<reflection::Case<'a>> {
-        let chunks = similar::capture_diff_slices(self.algorithm, self.old.as_bytes(), new.as_bytes());
-        let distance = distance(&chunks);
-        let result = self.op.eval(self.distance, distance);
+        let (result, chunks, measure) = self.run(new);
         if result == expected {
             Some(
                 reflection::Case::new(Some(self), result)
-                    .add_product(reflection::Product::new("distance", distance))
+                    .add_product(reflection::Product::new("measure", measure))
                     .add_product(reflection::Product::new(
                         "diff",
                         self.diff(&self.old, new, &chunks),
@@ -133,8 +214,8 @@ impl reflection::PredicateReflection for SimilarPredicate {
 impl fmt::Display for SimilarPredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.op {
-            DistanceOp::Similar => write!(f, "var - original <= {}", self.distance),
-            DistanceOp::Different => write!(f, "{} < var - original", self.distance),
+            SimilarOp::Similar => write!(f, "original is similar to var by {}", self.limit),
+            SimilarOp::Different => write!(f, "original differs from var by {}", self.limit)
         }
     }
 }
@@ -158,7 +239,7 @@ pub fn diff3<S>(old: S) -> SimilarPredicate
 where
     S: Into<borrow::Cow<'static, str>>,
 {
-    SimilarPredicate::new(old.into(), DistanceOp::Different)
+    SimilarPredicate::new(old.into(), SimilarOp::Different)
 }
 
 /// Creates a new `Predicate` that checks strings for how similar they are.
@@ -180,5 +261,5 @@ pub fn similar3<S>(old: S) -> SimilarPredicate
 where
     S: Into<borrow::Cow<'static, str>>,
 {
-    SimilarPredicate::new(old.into(), DistanceOp::Similar)
+    SimilarPredicate::new(old.into(), SimilarOp::Similar)
 }

--- a/src/str/similar.rs
+++ b/src/str/similar.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The predicates-rs Project Developers.
+// Copyright (c) 2021 The predicates-rs Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/str/similar.rs
+++ b/src/str/similar.rs
@@ -1,0 +1,166 @@
+// Copyright (c) 2018 The predicates-rs Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::borrow;
+use std::fmt;
+
+use crate::reflection;
+use crate::Predicate;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DistanceOp {
+    Similar,
+    Different,
+}
+
+impl DistanceOp {
+    fn eval(self, limit: i32, distance: i32) -> bool {
+        match self {
+            DistanceOp::Similar => distance <= limit,
+            DistanceOp::Different => limit < distance,
+        }
+    }
+}
+
+/// Predicate that diffs two strings.
+///
+/// This is created by the `predicate::str::similar`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SimilarPredicate {
+    old: borrow::Cow<'static, str>,
+    algorithm: similar::Algorithm,
+    distance: i32,
+    op: DistanceOp,
+}
+
+impl SimilarPredicate {
+    /// The maximum allowed edit distance.
+    ///
+    /// Default: `0`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use predicates::prelude::*;
+    ///
+    /// let predicate_fn = predicate::str::similar3("Hello World!").distance(1);
+    /// assert_eq!(true, predicate_fn.eval("Hello World!"));
+    /// assert_eq!(true, predicate_fn.eval("Hello World"));
+    ///
+    /// assert_eq!(false, predicate_fn.eval("Hello... World?"));
+    /// let dist = predicate_fn.find_case(false, "Hello... World?").unwrap().product_value("distance").unwrap();
+    /// assert_eq!("2", &dist);
+    /// ```
+    pub fn distance(mut self, distance: i32) -> Self {
+        self.distance = distance;
+        self
+    }
+
+    fn new(old: borrow::Cow<'static, str>, op: DistanceOp) -> Self {
+        Self{old, algorithm: similar::Algorithm::Myers, distance: 0, op}
+    }
+
+    fn diff(&self, chunks: &Vec<similar::DiffOp>) -> String {
+        use std::fmt::Write;
+        let mut f = String::with_capacity(chunks.len());
+        for c in chunks {
+            match *c {
+                similar::DiffOp::Equal{old_index, ..} => write!(f, "{}", old_index),
+                similar::DiffOp::Delete{old_index, ..} => write!(f, "\x1b[92m{}\x1b[0m", old_index),
+                similar::DiffOp::Insert{old_index, ..} => write!(f, "\x1b[91m{}\x1b[0m", old_index),
+                similar::DiffOp::Replace{old_index, ..} => write!(f, "\x1b[91m{}\x1b[0m", old_index),
+            }
+            .expect("write to String")
+        }
+        f
+    }
+}
+
+// TODO `similar offers a diff_ratio which might be better
+// TODO s/distance/changes/ ? Reserve "distance" for some levenstein-like metric ?
+fn distance(chunks: &Vec<similar::DiffOp>) -> i32 {
+    use similar::DiffOp::*;
+    chunks.iter().fold(0, |n, c| match c {
+        Equal{..} => n,
+        _ => n + 1,
+    })
+}
+
+impl Predicate<str> for SimilarPredicate {
+    fn eval(&self, new: &str) -> bool {
+        let chunks = similar::capture_diff_slices(self.algorithm, self.old.as_bytes(), new.as_bytes());
+        self.op.eval(self.distance, distance(&chunks))
+    }
+
+    fn find_case<'a>(&'a self, expected: bool, new: &str) -> Option<reflection::Case<'a>> {
+        let chunks = similar::capture_diff_slices(self.algorithm, self.old.as_bytes(), new.as_bytes());
+        let distance = distance(&chunks);
+        let result = self.op.eval(self.distance, distance);
+        if result == expected {
+            Some(
+                reflection::Case::new(Some(self), result)
+                    .add_product(reflection::Product::new("distance", distance))
+                    .add_product(reflection::Product::new("diff", self.diff(&chunks))),
+            )
+        } else {
+            None
+        }
+    }
+}
+
+impl reflection::PredicateReflection for SimilarPredicate {
+    fn parameters<'a>(&'a self) -> Box<dyn Iterator<Item = reflection::Parameter<'a>> + 'a> {
+        let params = vec![reflection::Parameter::new("original", &self.old)];
+        Box::new(params.into_iter())
+    }
+}
+
+impl fmt::Display for SimilarPredicate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.op {
+            DistanceOp::Similar => write!(f, "var - original <= {}", self.distance),
+            DistanceOp::Different => write!(f, "{} < var - original", self.distance),
+        }
+    }
+}
+
+/// Creates a new `Predicate` that diffs two strings.
+///
+/// # Examples
+///
+/// ```
+/// use predicates::prelude::*;
+///
+/// let predicate_fn = predicate::str::diff3("Hello World");
+/// assert_eq!(false, predicate_fn.eval("Hello World"));
+/// assert_eq!(true, predicate_fn.eval("Goodbye World"));
+/// ```
+pub fn diff3<S>(old: S) -> SimilarPredicate
+where
+    S: Into<borrow::Cow<'static, str>>,
+{
+    SimilarPredicate::new(old.into(), DistanceOp::Different)
+}
+
+/// Creates a new `Predicate` that checks strings for how similar they are.
+///
+/// # Examples
+///
+/// ```
+/// use predicates::prelude::*;
+///
+/// let predicate_fn = predicate::str::similar3("Hello World");
+/// assert_eq!(true, predicate_fn.eval("Hello World"));
+/// assert_eq!(false, predicate_fn.eval("Goodbye World"));
+/// ```
+pub fn similar3<S>(old: S) -> SimilarPredicate
+where
+    S: Into<borrow::Cow<'static, str>>,
+{
+    SimilarPredicate::new(old.into(), DistanceOp::Similar)
+}


### PR DESCRIPTION
This explores a fix for #94.

There are two replacement crates in this PR, but it only makes sense to merge one. Neither crate can be used as an exact replacement of the unmaintained crate, because the diffing algorithms don't match : the calculated "distance" is different and there is no way to configure a "split character".

Nevertheless, I used the two crates to showcase two possibilities:
- `dissimilar` retains the same API; programs will compile with only a function name change, but if they used to configure a split or a distance, the results may be different.
- `similar` ignores API stability, and exposes more features (even more could be exposed if we wanted)

Both crates have their own feature flag, and I resisted bikeshedding the name of the constructors.

IMHO the second one is more tempting, except if we want to avoid tying ourselves into a particular diffing crate and want to to the most common denominator features.

We could make a release that deprecates the `difference` feature and adds the `similar` feature, or we could make an immediate replacement (simplifying the bikeshedding and cosing the rustsec advisory faster).

TODO:
- Choose a path (this is my first PR here, so I won't dare)
- Update changelog and docs
- Change default feature
- Remove a diff crate or two
- Any other `similar` feature we want to expose ?