### PR TITLE
feat: Refine `CaseTreeInner` bounds

### DIFF
--- a/crates/tree/src/lib.rs
+++ b/crates/tree/src/lib.rs
@@ -24,20 +24,20 @@ impl<'a> CaseTreeExt for reflection::Case<'a> {
     }
 }
 
-type CaseTreeInner = treeline::Tree<Box<dyn fmt::Display>>;
+type CaseTreeInner = treeline::Tree<Box<dyn fmt::Display + Send + Sync>>;
 
 fn convert(case: &reflection::Case<'_>) -> CaseTreeInner {
     let mut leaves: Vec<CaseTreeInner> = vec![];
 
     leaves.extend(case.predicate().iter().flat_map(|pred| {
         pred.parameters().map(|item| {
-            let root: Box<dyn fmt::Display> = Box::new(item.to_string());
+            let root: Box<dyn fmt::Display + Send + Sync> = Box::new(item.to_string());
             treeline::Tree::new(root, vec![])
         })
     }));
 
     leaves.extend(case.products().map(|item| {
-        let root: Box<dyn fmt::Display> = Box::new(item.to_string());
+        let root: Box<dyn fmt::Display + Send + Sync> = Box::new(item.to_string());
         treeline::Tree::new(root, vec![])
     }));
 


### PR DESCRIPTION
Please see https://github.com/assert-rs/assert_cmd/pull/130 for the rationale behind this PR.

Separately, the `repository` entries in `predicates-core` and `predicates-tree`'s `Cargo.toml` files appear to be off. I could add those corrections to this PR, or submit them separately.