### PR TITLE
Implement `Send` and `Sync` for predicates with `PhantomData`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- All predicates now implement `Send` and `Sync` when it's appropriate
+
 ## [2.0.1] - 2021-07-26
 
 ### Changed

--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -29,6 +29,22 @@ where
     _phantom: PhantomData<Item>,
 }
 
+unsafe impl<M1, M2, Item> Send for AndPredicate<M1, M2, Item>
+where
+    M1: Predicate<Item> + Send,
+    M2: Predicate<Item> + Send,
+    Item: ?Sized,
+{
+}
+
+unsafe impl<M1, M2, Item> Sync for AndPredicate<M1, M2, Item>
+where
+    M1: Predicate<Item> + Sync,
+    M2: Predicate<Item> + Sync,
+    Item: ?Sized,
+{
+}
+
 impl<M1, M2, Item> AndPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
@@ -185,6 +201,22 @@ where
     _phantom: PhantomData<Item>,
 }
 
+unsafe impl<M1, M2, Item> Send for OrPredicate<M1, M2, Item>
+where
+    M1: Predicate<Item> + Send,
+    M2: Predicate<Item> + Send,
+    Item: ?Sized,
+{
+}
+
+unsafe impl<M1, M2, Item> Sync for OrPredicate<M1, M2, Item>
+where
+    M1: Predicate<Item> + Sync,
+    M2: Predicate<Item> + Sync,
+    Item: ?Sized,
+{
+}
+
 impl<M1, M2, Item> OrPredicate<M1, M2, Item>
 where
     M1: Predicate<Item>,
@@ -337,6 +369,20 @@ where
 {
     inner: M,
     _phantom: PhantomData<Item>,
+}
+
+unsafe impl<M, Item> Send for NotPredicate<M, Item>
+where
+    M: Predicate<Item> + Send,
+    Item: ?Sized,
+{
+}
+
+unsafe impl<M, Item> Sync for NotPredicate<M, Item>
+where
+    M: Predicate<Item> + Sync,
+    Item: ?Sized,
+{
 }
 
 impl<M, Item> NotPredicate<M, Item>

--- a/src/function.rs
+++ b/src/function.rs
@@ -28,6 +28,20 @@ where
     _phantom: PhantomData<T>,
 }
 
+unsafe impl<F, T> Send for FnPredicate<F, T>
+where
+    F: Send + Fn(&T) -> bool,
+    T: ?Sized,
+{
+}
+
+unsafe impl<F, T> Sync for FnPredicate<F, T>
+where
+    F: Sync + Fn(&T) -> bool,
+    T: ?Sized,
+{
+}
+
 impl<F, T> FnPredicate<F, T>
 where
     F: Fn(&T) -> bool,

--- a/src/name.rs
+++ b/src/name.rs
@@ -28,6 +28,20 @@ where
     _phantom: PhantomData<Item>,
 }
 
+unsafe impl<M, Item> Send for NamePredicate<M, Item>
+where
+    M: Predicate<Item> + Send,
+    Item: ?Sized,
+{
+}
+
+unsafe impl<M, Item> Sync for NamePredicate<M, Item>
+where
+    M: Predicate<Item> + Sync,
+    Item: ?Sized,
+{
+}
+
 impl<M, Item> Predicate<Item> for NamePredicate<M, Item>
 where
     M: Predicate<Item>,


### PR DESCRIPTION
Fix #108.

This fixes some predicates not being `Send` or `Sync` when `T` is not `Send` or `Sync`.
