### PR TITLE
fix: Report user value 

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -79,7 +79,12 @@ where
     }
 
     fn find_case<'a>(&'a self, expected: bool, variable: &T) -> Option<reflection::Case<'a>> {
-        utils::default_find_case(self, expected, variable)
+        utils::default_find_case(self, expected, variable).map(|case| {
+            case.add_product(reflection::Product::new(
+                "var",
+                utils::DebugAdapter::new(variable).to_string(),
+            ))
+        })
     }
 }
 
@@ -92,7 +97,12 @@ where
     }
 
     fn find_case<'b>(&'b self, expected: bool, variable: &T) -> Option<reflection::Case<'b>> {
-        utils::default_find_case(self, expected, variable)
+        utils::default_find_case(self, expected, variable).map(|case| {
+            case.add_product(reflection::Product::new(
+                "var",
+                utils::DebugAdapter::new(variable).to_string(),
+            ))
+        })
     }
 }
 
@@ -187,7 +197,12 @@ where
     }
 
     fn find_case<'a>(&'a self, expected: bool, variable: &T) -> Option<reflection::Case<'a>> {
-        utils::default_find_case(self, expected, variable)
+        utils::default_find_case(self, expected, variable).map(|case| {
+            case.add_product(reflection::Product::new(
+                "var",
+                utils::DebugAdapter::new(variable).to_string(),
+            ))
+        })
     }
 }
 
@@ -200,7 +215,12 @@ where
     }
 
     fn find_case<'b>(&'b self, expected: bool, variable: &T) -> Option<reflection::Case<'b>> {
-        utils::default_find_case(self, expected, variable)
+        utils::default_find_case(self, expected, variable).map(|case| {
+            case.add_product(reflection::Product::new(
+                "var",
+                utils::DebugAdapter::new(variable).to_string(),
+            ))
+        })
     }
 }
 
@@ -256,7 +276,12 @@ where
     }
 
     fn find_case<'a>(&'a self, expected: bool, variable: &T) -> Option<reflection::Case<'a>> {
-        utils::default_find_case(self, expected, variable)
+        utils::default_find_case(self, expected, variable).map(|case| {
+            case.add_product(reflection::Product::new(
+                "var",
+                utils::DebugAdapter::new(variable).to_string(),
+            ))
+        })
     }
 }
 
@@ -269,7 +294,12 @@ where
     }
 
     fn find_case<'b>(&'b self, expected: bool, variable: &T) -> Option<reflection::Case<'b>> {
-        utils::default_find_case(self, expected, variable)
+        utils::default_find_case(self, expected, variable).map(|case| {
+            case.add_product(reflection::Product::new(
+                "var",
+                utils::DebugAdapter::new(variable).to_string(),
+            ))
+        })
     }
 }
 

--- a/src/ord.rs
+++ b/src/ord.rs
@@ -85,10 +85,12 @@ where
         let palette = crate::Palette::current();
         write!(
             f,
-            "{} {} {:?}",
+            "{} {} {}",
             palette.var.paint("var"),
             palette.description.paint(self.op),
-            self.constant
+            palette
+                .expected
+                .paint(utils::DebugAdapter::new(&self.constant)),
         )
     }
 }
@@ -220,10 +222,12 @@ where
         let palette = crate::Palette::current();
         write!(
             f,
-            "{} {} {:?}",
+            "{} {} {}",
             palette.var.paint("var"),
             palette.description.paint(self.op),
-            self.constant
+            palette
+                .expected
+                .paint(utils::DebugAdapter::new(&self.constant)),
         )
     }
 }

--- a/src/ord.rs
+++ b/src/ord.rs
@@ -55,7 +55,12 @@ where
     }
 
     fn find_case<'a>(&'a self, expected: bool, variable: &T) -> Option<reflection::Case<'a>> {
-        utils::default_find_case(self, expected, variable)
+        utils::default_find_case(self, expected, variable).map(|case| {
+            case.add_product(reflection::Product::new(
+                "var",
+                utils::DebugAdapter::new(variable).to_string(),
+            ))
+        })
     }
 }
 
@@ -71,7 +76,12 @@ where
     }
 
     fn find_case<'b>(&'b self, expected: bool, variable: &T) -> Option<reflection::Case<'b>> {
-        utils::default_find_case(self, expected, variable)
+        utils::default_find_case(self, expected, variable).map(|case| {
+            case.add_product(reflection::Product::new(
+                "var",
+                utils::DebugAdapter::new(variable).to_string(),
+            ))
+        })
     }
 }
 
@@ -190,7 +200,12 @@ where
     }
 
     fn find_case<'a>(&'a self, expected: bool, variable: &T) -> Option<reflection::Case<'a>> {
-        utils::default_find_case(self, expected, variable)
+        utils::default_find_case(self, expected, variable).map(|case| {
+            case.add_product(reflection::Product::new(
+                "var",
+                utils::DebugAdapter::new(variable).to_string(),
+            ))
+        })
     }
 }
 
@@ -208,7 +223,12 @@ where
     }
 
     fn find_case<'b>(&'b self, expected: bool, variable: &T) -> Option<reflection::Case<'b>> {
-        utils::default_find_case(self, expected, variable)
+        utils::default_find_case(self, expected, variable).map(|case| {
+            case.add_product(reflection::Product::new(
+                "var",
+                utils::DebugAdapter::new(variable).to_string(),
+            ))
+        })
     }
 }
 

--- a/src/path/existence.rs
+++ b/src/path/existence.rs
@@ -31,7 +31,12 @@ impl Predicate<path::Path> for ExistencePredicate {
         expected: bool,
         variable: &path::Path,
     ) -> Option<reflection::Case<'a>> {
-        utils::default_find_case(self, expected, variable)
+        utils::default_find_case(self, expected, variable).map(|case| {
+            case.add_product(reflection::Product::new(
+                "var",
+                variable.display().to_string(),
+            ))
+        })
     }
 }
 

--- a/src/path/fc.rs
+++ b/src/path/fc.rs
@@ -75,10 +75,19 @@ where
     ) -> Option<reflection::Case<'a>> {
         let buffer = read_file(variable);
         match (expected, buffer) {
-            (_, Ok(buffer)) => self.p.find_case(expected, &buffer),
+            (_, Ok(buffer)) => self.p.find_case(expected, &buffer).map(|case| {
+                case.add_product(reflection::Product::new(
+                    "var",
+                    variable.display().to_string(),
+                ))
+            }),
             (true, Err(_)) => None,
             (false, Err(err)) => Some(
                 reflection::Case::new(Some(self), false)
+                    .add_product(reflection::Product::new(
+                        "var",
+                        variable.display().to_string(),
+                    ))
                     .add_product(reflection::Product::new("error", err)),
             ),
         }

--- a/src/path/fc.rs
+++ b/src/path/fc.rs
@@ -75,10 +75,7 @@ where
     ) -> Option<reflection::Case<'a>> {
         let buffer = read_file(variable);
         match (expected, buffer) {
-            (_, Ok(buffer)) => self
-                .p
-                .find_case(expected, &buffer)
-                .map(|child| reflection::Case::new(Some(self), expected).add_child(child)),
+            (_, Ok(buffer)) => self.p.find_case(expected, &buffer),
             (true, Err(_)) => None,
             (false, Err(err)) => Some(
                 reflection::Case::new(Some(self), false)

--- a/src/str/basics.rs
+++ b/src/str/basics.rs
@@ -25,6 +25,7 @@ impl Predicate<str> for IsEmptyPredicate {
 
     fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
         utils::default_find_case(self, expected, variable)
+            .map(|case| case.add_product(reflection::Product::new("var", variable.to_owned())))
     }
 }
 
@@ -72,6 +73,7 @@ impl Predicate<str> for StartsWithPredicate {
 
     fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
         utils::default_find_case(self, expected, variable)
+            .map(|case| case.add_product(reflection::Product::new("var", variable.to_owned())))
     }
 }
 
@@ -125,6 +127,7 @@ impl Predicate<str> for EndsWithPredicate {
 
     fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
         utils::default_find_case(self, expected, variable)
+            .map(|case| case.add_product(reflection::Product::new("var", variable.to_owned())))
     }
 }
 
@@ -198,6 +201,7 @@ impl Predicate<str> for ContainsPredicate {
 
     fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
         utils::default_find_case(self, expected, variable)
+            .map(|case| case.add_product(reflection::Product::new("var", variable.to_owned())))
     }
 }
 
@@ -236,6 +240,7 @@ impl Predicate<str> for MatchesPredicate {
         if result == expected {
             Some(
                 reflection::Case::new(Some(self), result)
+                    .add_product(reflection::Product::new("var", variable.to_owned()))
                     .add_product(reflection::Product::new("actual count", actual_count)),
             )
         } else {

--- a/src/str/regex.rs
+++ b/src/str/regex.rs
@@ -47,6 +47,7 @@ impl Predicate<str> for RegexPredicate {
 
     fn find_case<'a>(&'a self, expected: bool, variable: &str) -> Option<reflection::Case<'a>> {
         utils::default_find_case(self, expected, variable)
+            .map(|case| case.add_product(reflection::Product::new("var", variable.to_owned())))
     }
 }
 
@@ -85,6 +86,7 @@ impl Predicate<str> for RegexMatchesPredicate {
         if result == expected {
             Some(
                 reflection::Case::new(Some(self), result)
+                    .add_product(reflection::Product::new("var", variable.to_owned()))
                     .add_product(reflection::Product::new("actual count", actual_count)),
             )
         } else {


### PR DESCRIPTION
With some predicates, we show the user value (diff) but others do not.
This makes it more consistent.  We aim to show the user value in leaf
predicates and in major adapters.
- Some leaf predicates can't show a value (function)
- Some defer to a file on disk, so we leave it at that, in case the file
  is too big or ugly to shoe
- Simple adapters, like `trim` don't show.  So far, the only worthwhile
  one is `eq_file`.

By leaving things to the leaves, we are able to show the value after its
gone through transforms, like UTF-8, or loading a file path.

Fixes #116