### PR TITLE
docs: Fix `not`s link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@
 //! [`path_pred = bytes_pred.from_file_path`]: prelude::PredicateFileContentExt::from_file_path()
 //! [`path_pred = predicate::path::eq_file`]: prelude::predicate::path::eq_file()
 //! [`pred_a.and(pred_b)`]: boolean::PredicateBooleanExt::and()
-//! [`pred_a.not())`]: boolean::PredicateBooleanExt::not()
+//! [`pred_a.not()`]: boolean::PredicateBooleanExt::not()
 //! [`pred_a.or(pred_b)`]: boolean::PredicateBooleanExt::or()
 //! [`predicate::always`]: constant::always()
 //! [`predicate::eq`]: ord::eq()


### PR DESCRIPTION
Thought we didn't document this but apparently I missed it though the
link was broken.

Fixes #120

<!--
Quick reminders:
- Was CHANGELOG.md updated?
- Were tests written?
- Is commit history clean?
- Were copyright statements updated?
- Was the predicate guide updated?
-->
