### PR TITLE
feat!: Always print color when color is enabled 

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-msrv = "1.60.0"  # MSRV
+msrv = "1.64.0"  # MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - name: No-default features
       run: cargo test --workspace --no-default-features
   msrv:
-    name: "Check MSRV: 1.60.0"
+    name: "Check MSRV: 1.64.0"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -59,7 +59,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.60.0  # MSRV
+        toolchain: 1.64.0  # MSRV
         profile: minimal
         override: true
     - uses: Swatinem/rust-cache@v2
@@ -113,7 +113,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.60.0  # MSRV
+        toolchain: 1.64.0  # MSRV
         profile: minimal
         override: true
         components: clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,7 @@ normalize-line-endings = { version = "0.3.0", optional = true }
 regex = { version="1.0", optional = true }
 float-cmp = { version="0.9", optional = true }
 itertools = "0.10"
-yansi = { version = "0.5.1", optional = true }
-concolor = { version = "0.0.12", optional = true }
+anstyle = "0.3.0"
 
 [dev-dependencies]
 predicates-tree = { version = "1.0", path = "crates/tree" }
@@ -60,5 +59,4 @@ predicates-tree = { version = "1.0", path = "crates/tree" }
 default = ["diff", "regex", "float-cmp", "normalize-line-endings"]
 diff = ["dep:difflib"]
 unstable = []
-color = ["dep:yansi", "dep:concolor", "concolor?/std"]
-color-auto = ["color", "concolor?/auto"]
+color = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,27 +1,36 @@
 [workspace]
 members = ["crates/*"]
+resolver = "2"
+
+[workspace.package]
+license = "MIT OR Apache-2.0"
+edition = "2021"
+rust-version = "1.64.0"  # MSRV
+include = [
+  "build.rs",
+  "src/**/*",
+  "Cargo.toml",
+  "LICENSE*",
+  "README.md",
+  "benches/**/*",
+  "examples/**/*"
+]
 
 [package]
 name = "predicates"
 version = "2.1.5"
 description = "An implementation of boolean-valued predicate functions."
 authors = ["Nick Stevens <nick@bitcurry.com>"]
-license = "MIT OR Apache-2.0"
 repository = "https://github.com/assert-rs/predicates-rs"
 homepage = "https://github.com/assert-rs/predicates-rs"
 documentation = "https://docs.rs/predicates"
 readme = "README.md"
 categories = ["data-structures", "rust-patterns"]
 keywords = ["predicate", "boolean", "combinatorial", "match", "logic"]
-edition = "2021"
-rust-version = "1.60.0"  # MSRV
-include = [
-  "src/**/*",
-  "Cargo.toml",
-  "LICENSE*",
-  "README.md",
-  "examples/**/*"
-]
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+include.workspace = true
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ anstyle = "0.3.0"
 predicates-tree = { version = "1.0", path = "crates/tree" }
 
 [features]
-default = ["diff", "regex", "float-cmp", "normalize-line-endings"]
+default = ["diff", "regex", "float-cmp", "normalize-line-endings", "color"]
 diff = ["dep:difflib"]
 unstable = []
 color = []

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -3,19 +3,13 @@ name = "predicates-core"
 version = "1.0.5"
 description = "An API for boolean-valued predicate functions."
 authors = ["Nick Stevens <nick@bitcurry.com>"]
-license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/assert-rs/predicates-rs/tree/master/crates/core"
 homepage = "https://github.com/assert-rs/predicates-rs/tree/master/crates/core"
 documentation = "https://docs.rs/predicates-core"
 categories = ["data-structures", "rust-patterns"]
 keywords = ["predicate", "boolean", "combinatorial", "match", "logic"]
-edition = "2021"
-rust-version = "1.60.0"  # MSRV
-include = [
-  "src/**/*",
-  "Cargo.toml",
-  "LICENSE*",
-  "README.md",
-  "examples/**/*"
-]
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+include.workspace = true

--- a/crates/tree/Cargo.toml
+++ b/crates/tree/Cargo.toml
@@ -16,7 +16,7 @@ include.workspace = true
 
 [dependencies]
 predicates-core = { version = "1.0", path = "../core" }
-termtree = "0.4"
+termtree = "0.4.1"
 
 [dev-dependencies]
-predicates = { version = "2.1", path = "../..", features = ["color-auto"] }
+predicates = { version = "2.1", path = "../..", features = ["color"] }

--- a/crates/tree/Cargo.toml
+++ b/crates/tree/Cargo.toml
@@ -3,22 +3,16 @@ name = "predicates-tree"
 version = "1.0.7"
 authors = ["Nick Stevens <nick@bitcurry.com>"]
 description = "Render boolean-valued predicate functions results as a tree."
-license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/assert-rs/predicates-rs/tree/master/crates/tree"
 homepage = "https://github.com/assert-rs/predicates-rs/tree/master/crates/tree"
 documentation = "https://docs.rs/predicates-tree"
 categories = ["data-structures", "rust-patterns"]
 keywords = ["predicate", "boolean", "combinatorial", "match", "logic"]
-edition = "2021"
-rust-version = "1.60.0"  # MSRV
-include = [
-  "src/**/*",
-  "Cargo.toml",
-  "LICENSE*",
-  "README.md",
-  "examples/**/*"
-]
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+include.workspace = true
 
 [dependencies]
 predicates-core = { version = "1.0", path = "../core" }

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -41,8 +41,8 @@ impl reflection::PredicateReflection for BooleanPredicate {
 
 impl fmt::Display for BooleanPredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
-        write!(f, "{}", palette.expected.paint(self.retval))
+        let palette = crate::Palette::new(f.alternate());
+        write!(f, "{}", palette.expected(self.retval))
     }
 }
 

--- a/src/float/close.rs
+++ b/src/float/close.rs
@@ -124,13 +124,13 @@ impl reflection::PredicateReflection for IsClosePredicate {
 
 impl fmt::Display for IsClosePredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{} {} {}",
-            palette.var.paint("var"),
-            palette.description.paint("!="),
-            palette.expected.paint(self.target),
+            palette.var("var"),
+            palette.description("!="),
+            palette.expected(self.target),
         )
     }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -17,6 +17,7 @@ use crate::Predicate;
 
 /// Predicate that wraps a function over a reference that returns a `bool`.
 /// This type is returned by the `predicate::function` function.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FnPredicate<F, T>
 where

--- a/src/function.rs
+++ b/src/function.rs
@@ -96,12 +96,12 @@ where
     T: ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{}({})",
-            palette.description.paint(self.name),
-            palette.var.paint("var"),
+            palette.description(self.name),
+            palette.var("var"),
         )
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -109,13 +109,13 @@ where
     T: PartialEq + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{} {} {}",
-            palette.var.paint("var"),
-            palette.description.paint("in"),
-            palette.expected.paint("values")
+            palette.var("var"),
+            palette.description("in"),
+            palette.expected("values")
         )
     }
 }
@@ -218,13 +218,13 @@ where
     T: Ord + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{} {} {}",
-            palette.var.paint("var"),
-            palette.description.paint("in"),
-            palette.expected.paint("values")
+            palette.var("var"),
+            palette.description("in"),
+            palette.expected("values")
         )
     }
 }
@@ -280,13 +280,13 @@ where
     T: Hash + Eq + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{} {} {}",
-            palette.var.paint("var"),
-            palette.description.paint("in"),
-            palette.expected.paint("values")
+            palette.var("var"),
+            palette.description("in"),
+            palette.expected("values")
         )
     }
 }

--- a/src/name.rs
+++ b/src/name.rs
@@ -75,8 +75,8 @@ where
     Item: ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
-        write!(f, "{}", palette.description.paint(self.name))
+        let palette = crate::Palette::new(f.alternate());
+        write!(f, "{}", palette.description(self.name))
     }
 }
 

--- a/src/ord.rs
+++ b/src/ord.rs
@@ -69,15 +69,13 @@ where
     T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{} {} {}",
-            palette.var.paint("var"),
-            palette.description.paint(self.op),
-            palette
-                .expected
-                .paint(utils::DebugAdapter::new(&self.constant)),
+            palette.var("var"),
+            palette.description(self.op),
+            palette.expected(utils::DebugAdapter::new(&self.constant)),
         )
     }
 }
@@ -195,15 +193,13 @@ where
     T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{} {} {}",
-            palette.var.paint("var"),
-            palette.description.paint(self.op),
-            palette
-                .expected
-                .paint(utils::DebugAdapter::new(&self.constant)),
+            palette.var("var"),
+            palette.description(self.op),
+            palette.expected(utils::DebugAdapter::new(&self.constant)),
         )
     }
 }

--- a/src/path/existence.rs
+++ b/src/path/existence.rs
@@ -44,14 +44,12 @@ impl reflection::PredicateReflection for ExistencePredicate {}
 
 impl fmt::Display for ExistencePredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{}({})",
-            palette
-                .description
-                .paint(if self.exists { "exists" } else { "missing" }),
-            palette.var.paint("var")
+            palette.description(if self.exists { "exists" } else { "missing" }),
+            palette.var("var")
         )
     }
 }

--- a/src/path/fs.rs
+++ b/src/path/fs.rs
@@ -89,13 +89,13 @@ impl reflection::PredicateReflection for BinaryFilePredicate {
 
 impl fmt::Display for BinaryFilePredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{} {} {}",
-            palette.var.paint("var"),
-            palette.description.paint("is"),
-            palette.expected.paint(self.path.display())
+            palette.var("var"),
+            palette.description("is"),
+            palette.expected(self.path.display())
         )
     }
 }
@@ -167,13 +167,13 @@ impl reflection::PredicateReflection for StrFilePredicate {
 
 impl fmt::Display for StrFilePredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{} {} {}",
-            palette.var.paint("var"),
-            palette.description.paint("is"),
-            palette.expected.paint(self.path.display())
+            palette.var("var"),
+            palette.description("is"),
+            palette.expected(self.path.display())
         )
     }
 }

--- a/src/path/ft.rs
+++ b/src/path/ft.rs
@@ -135,13 +135,13 @@ impl reflection::PredicateReflection for FileTypePredicate {
 
 impl fmt::Display for FileTypePredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{} {} {}",
-            palette.var.paint("var"),
-            palette.description.paint("is"),
-            palette.expected.paint(self.ft)
+            palette.var("var"),
+            palette.description("is"),
+            palette.expected(self.ft)
         )
     }
 }

--- a/src/str/basics.rs
+++ b/src/str/basics.rs
@@ -33,12 +33,12 @@ impl reflection::PredicateReflection for IsEmptyPredicate {}
 
 impl fmt::Display for IsEmptyPredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{}.{}()",
-            palette.var.paint("var"),
-            palette.description.paint("is_empty"),
+            palette.var("var"),
+            palette.description("is_empty"),
         )
     }
 }
@@ -81,12 +81,12 @@ impl reflection::PredicateReflection for StartsWithPredicate {}
 
 impl fmt::Display for StartsWithPredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{}.{}({:?})",
-            palette.var.paint("var"),
-            palette.description.paint("starts_with"),
+            palette.var("var"),
+            palette.description("starts_with"),
             self.pattern
         )
     }
@@ -135,12 +135,12 @@ impl reflection::PredicateReflection for EndsWithPredicate {}
 
 impl fmt::Display for EndsWithPredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{}.{}({:?})",
-            palette.var.paint("var"),
-            palette.description.paint("ends_with"),
+            palette.var("var"),
+            palette.description("ends_with"),
             self.pattern
         )
     }
@@ -209,13 +209,13 @@ impl reflection::PredicateReflection for ContainsPredicate {}
 
 impl fmt::Display for ContainsPredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{}.{}({})",
-            palette.var.paint("var"),
-            palette.description.paint("contains"),
-            palette.expected.paint(&self.pattern),
+            palette.var("var"),
+            palette.description("contains"),
+            palette.expected(&self.pattern),
         )
     }
 }
@@ -258,13 +258,13 @@ impl reflection::PredicateReflection for MatchesPredicate {
 
 impl fmt::Display for MatchesPredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{}.{}({})",
-            palette.var.paint("var"),
-            palette.description.paint("contains"),
-            palette.expected.paint(&self.pattern),
+            palette.var("var"),
+            palette.description("contains"),
+            palette.expected(&self.pattern),
         )
     }
 }

--- a/src/str/difference.rs
+++ b/src/str/difference.rs
@@ -98,7 +98,7 @@ where
 #[cfg(feature = "color")]
 fn colorize_diff(mut lines: Vec<String>, palette: crate::Palette) -> Vec<String> {
     for (i, line) in lines.iter_mut().enumerate() {
-        match (i, line.as_bytes().get(0)) {
+        match (i, line.as_bytes().first()) {
             (0, _) => {
                 if let Some((prefix, body)) = line.split_once(' ') {
                     *line = format!("{:#} {}", palette.expected(prefix), body);

--- a/src/str/difference.rs
+++ b/src/str/difference.rs
@@ -30,7 +30,7 @@ impl Predicate<str> for DifferencePredicate {
         if result == expected {
             None
         } else {
-            let palette = crate::Palette::current();
+            let palette = crate::Palette::new(true);
             let orig: Vec<_> = self.orig.lines().map(|l| format!("{}\n", l)).collect();
             let variable: Vec<_> = variable.lines().map(|l| format!("{}\n", l)).collect();
             let diff = difflib::unified_diff(
@@ -38,8 +38,8 @@ impl Predicate<str> for DifferencePredicate {
                 &variable,
                 "",
                 "",
-                &palette.expected.paint("orig").to_string(),
-                &palette.var.paint("var").to_string(),
+                &palette.expected("orig").to_string(),
+                &palette.var("var").to_string(),
                 0,
             );
             let mut diff = colorize_diff(diff, palette);
@@ -64,13 +64,13 @@ impl reflection::PredicateReflection for DifferencePredicate {
 
 impl fmt::Display for DifferencePredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{} {} {}",
-            palette.description.paint("diff"),
-            palette.expected.paint("original"),
-            palette.var.paint("var"),
+            palette.description("diff"),
+            palette.expected("original"),
+            palette.var("var"),
         )
     }
 }
@@ -101,24 +101,24 @@ fn colorize_diff(mut lines: Vec<String>, palette: crate::Palette) -> Vec<String>
         match (i, line.as_bytes().get(0)) {
             (0, _) => {
                 if let Some((prefix, body)) = line.split_once(' ') {
-                    *line = format!("{} {}", palette.expected.paint(prefix), body);
+                    *line = format!("{:#} {}", palette.expected(prefix), body);
                 }
             }
             (1, _) => {
                 if let Some((prefix, body)) = line.split_once(' ') {
-                    *line = format!("{} {}", palette.var.paint(prefix), body);
+                    *line = format!("{:#} {}", palette.var(prefix), body);
                 }
             }
             (_, Some(b'-')) => {
                 let (prefix, body) = line.split_at(1);
-                *line = format!("{}{}", palette.expected.paint(prefix), body);
+                *line = format!("{:#}{}", palette.expected(prefix), body);
             }
             (_, Some(b'+')) => {
                 let (prefix, body) = line.split_at(1);
-                *line = format!("{}{}", palette.var.paint(prefix), body);
+                *line = format!("{:#}{}", palette.var(prefix), body);
             }
             (_, Some(b'@')) => {
-                *line = format!("{}", palette.description.paint(&line));
+                *line = format!("{:#}", palette.description(&line));
             }
             _ => (),
         }

--- a/src/str/regex.rs
+++ b/src/str/regex.rs
@@ -55,13 +55,13 @@ impl reflection::PredicateReflection for RegexPredicate {}
 
 impl fmt::Display for RegexPredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{}.{}({})",
-            palette.var.paint("var"),
-            palette.description.paint("is_match"),
-            palette.expected.paint(&self.re),
+            palette.var("var"),
+            palette.description("is_match"),
+            palette.expected(&self.re),
         )
     }
 }
@@ -104,13 +104,13 @@ impl reflection::PredicateReflection for RegexMatchesPredicate {
 
 impl fmt::Display for RegexMatchesPredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let palette = crate::Palette::current();
+        let palette = crate::Palette::new(f.alternate());
         write!(
             f,
             "{}.{}({})",
-            palette.var.paint("var"),
-            palette.description.paint("is_match"),
-            palette.expected.paint(&self.re),
+            palette.var("var"),
+            palette.description("is_match"),
+            palette.expected(&self.re),
         )
     }
 }


### PR DESCRIPTION
This is in anticipation of callers using `anstyle_stream` to print this
which will "Do The Right Thing"

BREAKING CHANGE:
- `color-auto` is gone
- `Display`s won't automatically print ANSI color code when
  appropriate but instead `format!("{}", case)` will never print color
  and `format!("{:#}", case)` will always print color