### PR TITLE
feat!: Disable default regex features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Breaking Changes
+
+- Enabling the `regex` feature does not enable the default features of the `regex` crate (except `std`) anymore.
+
 ## [3.0.3] - 2023-04-13
 
 ### Internal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ pre-release-replacements = [
 predicates-core = { version = "1.0", path = "crates/core" }
 difflib = { version = "0.4", optional = true }
 normalize-line-endings = { version = "0.3.0", optional = true }
-regex = { version="1.0", optional = true }
+regex = { version="1.0", default-features = false, features = ["std"], optional = true }
 float-cmp = { version="0.9", optional = true }
 itertools = "0.10"
 anstyle = "1.0.0"


### PR DESCRIPTION
To avoid infecting the dependency graph with potentially unwanted regex features. If the user wants extra regex features, they should enable them in their project (e.g. just add dependency on "regex" with default features enabled).

<!--
Quick reminders:
- Was CHANGELOG.md updated?
- Were tests written?
- Is commit history clean?
- Were copyright statements updated?
- Was the predicate guide updated?
-->
