### PR TITLE
feat: implement `PredicateBoxExt` for `?Sized` `Item`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- The `boxed` function is now available for predicates with an `Item` type that
+  is not `Sized`.
+
 ## [3.1.2] - 2024-07-25
 
 ## [3.1.1] - 2024-07-25

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -114,4 +114,15 @@ where
     }
 }
 
-impl<P, Item> PredicateBoxExt<Item> for P where P: Predicate<Item> {}
+impl<P, Item: ?Sized> PredicateBoxExt<Item> for P where P: Predicate<Item> {}
+
+#[cfg(test)]
+mod test {
+    use crate::prelude::*;
+
+    #[test]
+    fn unsized_boxed() {
+        let p = predicate::always().boxed();
+        p.eval("4");
+    }
+}


### PR DESCRIPTION
This looks like an oversight: the trait itself already had `Item: ?Sized` but the generic `impl` did not.

I noticed this while trying to chain together a variable number of `predicate::str::contains(...)` with `and()`. Calling `predicates::BoxPredicate::new()` explicitly works, but is much wordier than `.boxed()`, which fails:

```
173 | pub struct ContainsPredicate {
    | ---------------------------- doesn't satisfy `_: PredicateBoxExt<str>`
    |
    = note: the following trait bounds were not satisfied:
            `str: Sized`
            which is required by `ContainsPredicate: predicates::PredicateBoxExt<str>`
            `&ContainsPredicate: Predicate<_>`
            which is required by `&ContainsPredicate: predicates::PredicateBoxExt<_>`
            `&mut ContainsPredicate: Predicate<_>`
            which is required by `&mut ContainsPredicate: predicates::PredicateBoxExt<_>`
```
 

<!--
Quick reminders:
- Was CHANGELOG.md updated?
- Were tests written?
- Is commit history clean?
- Were copyright statements updated?
- Was the predicate guide updated?
-->
