### PR TITLE
docs(path): mention utf8() in eq_file documentation

### DIFF
--- a/src/path/fs.rs
+++ b/src/path/fs.rs
@@ -100,7 +100,10 @@ impl fmt::Display for BinaryFilePredicate {
     }
 }
 
-/// Creates a new `Predicate` that ensures complete equality
+/// Creates a new `Predicate` that ensures complete equality of file contents as bytes.
+///
+/// For text files, prefer [`BinaryFilePredicate::utf8`] to compare UTF-8 strings and get
+/// clearer mismatch output instead of raw byte lists.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Summary

Document that `eq_file` compares file contents as bytes by default, and point users to [`BinaryFilePredicate::utf8`](https://docs.rs/predicates/latest/predicates/path/struct.BinaryFilePredicate.html#method.utf8) for UTF-8 text comparisons with clearer mismatch output.

Fixes #145

## Test plan

- [x] `cargo test --doc` (48 doctests passed)